### PR TITLE
Make the forever loop optional after the spark app

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -22,7 +22,7 @@ else
 fi
 
 # Sleep forever so the process does not complete
-if [ $FOREVER_LOOP ]
+if [ $FROM_DEPLOYMENTCONFIG ]
 then
     while true
     do

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -2,14 +2,14 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-pyspark",
+      "name": "oshinko-pyspark-dc",
       "annotations": {
-         "description": "Application template for oshinko pyspark using STI"
+         "description": "Oshinko pyspark using STI and an application submitted as a deploymentconfig"
       }
    },
    "labels": {
       "application": "oshinko-pyspark",
-      "createdBy": "template-oshinko-pyspark"
+      "createdBy": "template-oshinko-pyspark-dc"
    },
    "parameters": [
       {
@@ -30,6 +30,10 @@
          "description": "Name of the main py file to run",
          "name": "APP_FILE",
          "value": "app.py"
+      },
+      {
+         "description": "Command line arguments to pass to the spark application",
+         "name": "APP_ARGS"
       },
       {
          "description": "Git source URI for application",
@@ -114,7 +118,7 @@
          },
          "spec": {
             "strategy": {
-               "type": "Recreate"
+               "type": "Rolling"
             },
             "triggers": [
                {
@@ -153,6 +157,14 @@
                            {
                               "name": "OSHINKO_CLUSTER_NAME",
                               "value": "${OSHINKO_CLUSTER_NAME}"
+                           },
+                           {
+                              "name": "APP_ARGS",
+                              "value": "${APP_ARGS}"
+                           },
+                           {
+                              "name": "FROM_DEPLOYMENTCONFIG",
+                              "value": true
                            }
                         ],
                         "resources": {},


### PR DESCRIPTION
The forever loop is necessary when using a deploymentconfig
to run a spark app, but not when we use a kubernetes job
object. Add an optional env var to turn on the forever
loop, but skip it by default.
