### PR TITLE
Use the MasterWebURL field from the cluster response in start.sh

### DIFF
--- a/common/oshinko-get-cluster/oshinko-get-cluster.go
+++ b/common/oshinko-get-cluster/oshinko-get-cluster.go
@@ -165,6 +165,7 @@ func main() {
 		if cl != nil {
 			fmt.Println(*cl.WorkerCount)
 			fmt.Println(*cl.MasterURL)
+			fmt.Println(*cl.MasterWebURL)
 		}
 		os.Exit(0)
 	}


### PR DESCRIPTION
The start script for the spark application was assuming too much
about the form of the spark master web url. The web url is now
being returned as part of a standard cluster object, so it uses
that field instead.
