### PR TITLE
Update the oshinko-rest vendor directory for the new model

### DIFF
--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/create_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/create_cluster_parameters.go
@@ -4,8 +4,11 @@ package clusters
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -16,7 +19,20 @@ import (
 // with the default values initialized.
 func NewCreateClusterParams() *CreateClusterParams {
 	var ()
-	return &CreateClusterParams{}
+	return &CreateClusterParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewCreateClusterParamsWithTimeout creates a new CreateClusterParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewCreateClusterParamsWithTimeout(timeout time.Duration) *CreateClusterParams {
+	var ()
+	return &CreateClusterParams{
+
+		timeout: timeout,
+	}
 }
 
 /*CreateClusterParams contains all the parameters to send to the API endpoint
@@ -29,6 +45,8 @@ type CreateClusterParams struct {
 
 	*/
 	Cluster *models.NewCluster
+
+	timeout time.Duration
 }
 
 // WithCluster adds the cluster to the create cluster params
@@ -40,6 +58,7 @@ func (o *CreateClusterParams) WithCluster(Cluster *models.NewCluster) *CreateClu
 // WriteToRequest writes these params to a swagger request
 func (o *CreateClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Cluster == nil {

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/delete_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/delete_single_cluster_parameters.go
@@ -4,8 +4,11 @@ package clusters
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewDeleteSingleClusterParams() *DeleteSingleClusterParams {
 	var ()
-	return &DeleteSingleClusterParams{}
+	return &DeleteSingleClusterParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewDeleteSingleClusterParamsWithTimeout creates a new DeleteSingleClusterParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewDeleteSingleClusterParamsWithTimeout(timeout time.Duration) *DeleteSingleClusterParams {
+	var ()
+	return &DeleteSingleClusterParams{
+
+		timeout: timeout,
+	}
 }
 
 /*DeleteSingleClusterParams contains all the parameters to send to the API endpoint
@@ -27,6 +43,8 @@ type DeleteSingleClusterParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithName adds the name to the delete single cluster params
@@ -38,6 +56,7 @@ func (o *DeleteSingleClusterParams) WithName(Name string) *DeleteSingleClusterPa
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteSingleClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param name

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_clusters_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_clusters_parameters.go
@@ -4,8 +4,11 @@ package clusters
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewFindClustersParams() *FindClustersParams {
 
-	return &FindClustersParams{}
+	return &FindClustersParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewFindClustersParamsWithTimeout creates a new FindClustersParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewFindClustersParamsWithTimeout(timeout time.Duration) *FindClustersParams {
+
+	return &FindClustersParams{
+
+		timeout: timeout,
+	}
 }
 
 /*FindClustersParams contains all the parameters to send to the API endpoint
 for the find clusters operation typically these are written to a http.Request
 */
 type FindClustersParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *FindClustersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_clusters_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_clusters_responses.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 
 	strfmt "github.com/go-openapi/strfmt"
@@ -124,6 +125,12 @@ type ClustersItems0 struct {
 	*/
 	MasterURL *string `json:"masterUrl"`
 
+	/* URL to the spark master web UI
+
+	Required: true
+	*/
+	MasterWebURL *string `json:"masterWebUrl"`
+
 	/* Name of the cluster
 
 	Required: true
@@ -153,6 +160,11 @@ func (o *ClustersItems0) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := o.validateMasterURL(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := o.validateMasterWebURL(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -190,6 +202,15 @@ func (o *ClustersItems0) validateHref(formats strfmt.Registry) error {
 func (o *ClustersItems0) validateMasterURL(formats strfmt.Registry) error {
 
 	if err := validate.Required("masterUrl", "body", o.MasterURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *ClustersItems0) validateMasterWebURL(formats strfmt.Registry) error {
+
+	if err := validate.Required("masterWebUrl", "body", o.MasterWebURL); err != nil {
 		return err
 	}
 
@@ -255,6 +276,21 @@ func (o *FindClustersOKBodyBody) validateClusters(formats strfmt.Registry) error
 
 	if err := validate.Required("findClustersOK"+"."+"clusters", "body", o.Clusters); err != nil {
 		return err
+	}
+
+	for i := 0; i < len(o.Clusters); i++ {
+
+		if swag.IsZero(o.Clusters[i]) { // not required
+			continue
+		}
+
+		if o.Clusters[i] != nil {
+
+			if err := o.Clusters[i].Validate(formats); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/find_single_cluster_parameters.go
@@ -4,8 +4,11 @@ package clusters
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,7 +17,20 @@ import (
 // with the default values initialized.
 func NewFindSingleClusterParams() *FindSingleClusterParams {
 	var ()
-	return &FindSingleClusterParams{}
+	return &FindSingleClusterParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewFindSingleClusterParamsWithTimeout creates a new FindSingleClusterParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewFindSingleClusterParamsWithTimeout(timeout time.Duration) *FindSingleClusterParams {
+	var ()
+	return &FindSingleClusterParams{
+
+		timeout: timeout,
+	}
 }
 
 /*FindSingleClusterParams contains all the parameters to send to the API endpoint
@@ -27,6 +43,8 @@ type FindSingleClusterParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithName adds the name to the find single cluster params
@@ -38,6 +56,7 @@ func (o *FindSingleClusterParams) WithName(Name string) *FindSingleClusterParams
 // WriteToRequest writes these params to a swagger request
 func (o *FindSingleClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	// path param name

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/update_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/clusters/update_single_cluster_parameters.go
@@ -4,8 +4,11 @@ package clusters
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 
@@ -16,7 +19,20 @@ import (
 // with the default values initialized.
 func NewUpdateSingleClusterParams() *UpdateSingleClusterParams {
 	var ()
-	return &UpdateSingleClusterParams{}
+	return &UpdateSingleClusterParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewUpdateSingleClusterParamsWithTimeout creates a new UpdateSingleClusterParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewUpdateSingleClusterParamsWithTimeout(timeout time.Duration) *UpdateSingleClusterParams {
+	var ()
+	return &UpdateSingleClusterParams{
+
+		timeout: timeout,
+	}
 }
 
 /*UpdateSingleClusterParams contains all the parameters to send to the API endpoint
@@ -34,6 +50,8 @@ type UpdateSingleClusterParams struct {
 
 	*/
 	Name string
+
+	timeout time.Duration
 }
 
 // WithCluster adds the cluster to the update single cluster params
@@ -51,6 +69,7 @@ func (o *UpdateSingleClusterParams) WithName(Name string) *UpdateSingleClusterPa
 // WriteToRequest writes these params to a swagger request
 func (o *UpdateSingleClusterParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if o.Cluster == nil {

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/server/get_server_info_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/server/get_server_info_parameters.go
@@ -4,8 +4,11 @@ package server
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"time"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
+	cr "github.com/go-openapi/runtime/client"
 
 	strfmt "github.com/go-openapi/strfmt"
 )
@@ -14,18 +17,33 @@ import (
 // with the default values initialized.
 func NewGetServerInfoParams() *GetServerInfoParams {
 
-	return &GetServerInfoParams{}
+	return &GetServerInfoParams{
+
+		timeout: cr.DefaultTimeout,
+	}
+}
+
+// NewGetServerInfoParamsWithTimeout creates a new GetServerInfoParams object
+// with the default values initialized, and the ability to set a timeout on a request
+func NewGetServerInfoParamsWithTimeout(timeout time.Duration) *GetServerInfoParams {
+
+	return &GetServerInfoParams{
+
+		timeout: timeout,
+	}
 }
 
 /*GetServerInfoParams contains all the parameters to send to the API endpoint
 for the get server info operation typically these are written to a http.Request
 */
 type GetServerInfoParams struct {
+	timeout time.Duration
 }
 
 // WriteToRequest writes these params to a swagger request
 func (o *GetServerInfoParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
+	r.SetTimeout(o.timeout)
 	var res []error
 
 	if len(res) > 0 {

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/server/get_server_info_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/client/server/get_server_info_responses.go
@@ -123,6 +123,18 @@ type GetServerInfoOKBodyApplication struct {
 	Required: true
 	*/
 	Version *string `json:"version"`
+
+	/* Oshinko Web Service Name
+
+	Required: true
+	*/
+	WebServiceName *string `json:"web-service-name"`
+
+	/* Oshinko Web URL
+
+	Required: true
+	*/
+	WebURL *string `json:"web-url"`
 }
 
 // Validate validates this get server info o k body application
@@ -135,6 +147,16 @@ func (o *GetServerInfoOKBodyApplication) Validate(formats strfmt.Registry) error
 	}
 
 	if err := o.validateVersion(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := o.validateWebServiceName(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if err := o.validateWebURL(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -157,6 +179,24 @@ func (o *GetServerInfoOKBodyApplication) validateName(formats strfmt.Registry) e
 func (o *GetServerInfoOKBodyApplication) validateVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("getServerInfoOK"+"."+"application"+"."+"version", "body", o.Version); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *GetServerInfoOKBodyApplication) validateWebServiceName(formats strfmt.Registry) error {
+
+	if err := validate.Required("getServerInfoOK"+"."+"application"+"."+"web-service-name", "body", o.WebServiceName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *GetServerInfoOKBodyApplication) validateWebURL(formats strfmt.Registry) error {
+
+	if err := validate.Required("getServerInfoOK"+"."+"application"+"."+"web-url", "body", o.WebURL); err != nil {
 		return err
 	}
 

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/models/cluster_model.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/models/cluster_model.go
@@ -5,6 +5,7 @@ package models
 
 import (
 	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/validate"
@@ -22,6 +23,12 @@ type ClusterModel struct {
 	Required: true
 	*/
 	MasterURL *string `json:"masterUrl"`
+
+	/* URL to the spark master web UI
+
+	Required: true
+	*/
+	MasterWebURL *string `json:"masterWebUrl"`
 
 	/* Pods that make up the cluster
 
@@ -48,6 +55,10 @@ func (m *ClusterModel) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateMasterWebURL(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePods(formats); err != nil {
 		res = append(res, err)
 	}
@@ -71,10 +82,34 @@ func (m *ClusterModel) validateMasterURL(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *ClusterModel) validateMasterWebURL(formats strfmt.Registry) error {
+
+	if err := validate.Required("masterWebUrl", "body", m.MasterWebURL); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *ClusterModel) validatePods(formats strfmt.Registry) error {
 
 	if err := validate.Required("pods", "body", m.Pods); err != nil {
 		return err
+	}
+
+	for i := 0; i < len(m.Pods); i++ {
+
+		if swag.IsZero(m.Pods[i]) { // not required
+			continue
+		}
+
+		if m.Pods[i] != nil {
+
+			if err := m.Pods[i].Validate(formats); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/models/error_response.go
+++ b/common/oshinko-get-cluster/vendor/github.com/redhatanalytics/oshinko-rest/models/error_response.go
@@ -5,6 +5,7 @@ package models
 
 import (
 	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/validate"
@@ -49,6 +50,21 @@ func (m *ErrorResponse) validateErrors(formats strfmt.Registry) error {
 
 	if err := validate.MinItems("errors", "body", iErrorsSize, 1); err != nil {
 		return err
+	}
+
+	for i := 0; i < len(m.Errors); i++ {
+
+		if swag.IsZero(m.Errors[i]) { // not required
+			continue
+		}
+
+		if m.Errors[i] != nil {
+
+			if err := m.Errors[i].Validate(formats); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil


### PR DESCRIPTION
Recent changes in the cluster response object from oshinko-rest
make it necessary to update the client code in the vendor
directory for oshinko-get-cluster
