### PR TITLE
Add an export of spark master url

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -21,6 +21,10 @@ then
     master=${output[2]}
     masterweb=${output[3]}
 
+    # Now that we know what the master url is, export it so that the
+    # app can use it if it likes.
+    export OSHINKO_SPARK_MASTER=$master
+
     r=1
     while [ $r -ne 0 ]; do
         echo "Waiting for spark master to be available ..."


### PR DESCRIPTION
Set OSHINKO_SPARK_CLUSTER to the master url before
invoking spark-submit so that applications written to
pull the master url from the env can still work that way.
