### PR TITLE
Add APP_MAIN_CLASS input to the application templates

### DIFF
--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -36,7 +36,11 @@
          "name": "APP_ARGS"
       },
       {
-         "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here"
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
+          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       },
       {
@@ -180,7 +184,11 @@
                            },
                            {
                               "name": "SPARK_OPTIONS",
-                              "value": "${SPARK_OPTIONS}"
+                               "value": "${SPARK_OPTIONS}"
+			   },
+                           {
+                              "name": "APP_MAIN_CLASS",
+                              "value": "${APP_MAIN_CLASS}"
                            },
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -36,6 +36,10 @@
          "name": "APP_ARGS"
       },
       {
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       }
@@ -100,6 +104,10 @@
                            {
                               "name": "SPARK_OPTIONS",
                               "value": "${SPARK_OPTIONS}"
+                           },
+                           {
+                              "name": "APP_MAIN_CLASS",
+                              "value": "${APP_MAIN_CLASS}"
                            },
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -36,6 +36,10 @@
          "name": "APP_ARGS"
       },
       {
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       }
@@ -79,6 +83,10 @@
                                 {
                                    "name": "SPARK_OPTIONS",
                                    "value": "${SPARK_OPTIONS}"
+                                },
+                                {
+                                   "name": "APP_MAIN_CLASS",
+                                   "value": "${APP_MAIN_CLASS}"
                                 }
                               ]
                           }


### PR DESCRIPTION
This change exposes the APP_MAIN_CLASS env var. If set
the value of APP_MAIN_CLASS will be passed to spark-submit
using the --class flag.
