### PR TITLE
be explicit about cwd when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ clean: $(alldirs)
 push: $(pushdirs)
 
 $(alldirs):
-	${MAKE} -C $@ $(CMD)
+	cd $@; ${MAKE} $(CMD)
 
 .PHONY: build clean push $(alldirs)

--- a/common/Makefile
+++ b/common/Makefile
@@ -12,6 +12,6 @@ clean: oshinko-get-cluster
 	rm -f utils/oshinko-get-cluster
 
 oshinko-get-cluster:
-	${MAKE} -C $@ $(CMD)
+	cd $@; ${MAKE} $(CMD)
 
 .PHONY: oshinko-get-cluster


### PR DESCRIPTION
my go version go1.6.3 does not find the vendor dir when using make -C
but does it cd'ing explicitly