### PR TITLE
Always rely on the pod environment for the oshinko rest server

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -52,7 +52,7 @@ then
 
     if [ ${output[0]} == "creating" ] && [ "${OSHINKO_DEL_CLUSTER}" == "yes" ]; then
         echo "Deleting cluster"
-        $APP_ROOT/src/oshinko-get-cluster -delete -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME
+        $APP_ROOT/src/oshinko-get-cluster -delete $OSHINKO_CLUSTER_NAME
     fi
 else
     echo "$output"

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -9,8 +9,7 @@ source $APP_ROOT/etc/generate_container_user
 # Create the cluster through oshinko-rest if it does not exist
 # First line will say "creating" if it is creating the cluster
 # Second line will be the url of the spark master
-# If OSHINKO_REST is defined it will be used, otherwise the env will be scanned to find the rest server
-output=($($APP_ROOT/src/oshinko-get-cluster -create -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME))
+output=($($APP_ROOT/src/oshinko-get-cluster -create $OSHINKO_CLUSTER_NAME))
 res=$?
 
 # Build the spark-submit command and execute


### PR DESCRIPTION
The oshinko-get-cluster utility can take an optional "-server" argument
to specify the oshinko rest server which is useful for testing or
running outside of a pod.  However, start.sh will always run in
a pod and should always scan the pod env to discover the rest
server, therefore this optional flag can be removed from start.sh