### PR TITLE
Expose the ephemeral cluster delete option in the templates

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -51,7 +51,8 @@ then
     echo spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
 
-    if [ ${output[0]} == "creating" ] && [ "${OSHINKO_DEL_CLUSTER}" == "yes" ]; then
+
+    if [ ${output[0]} == "creating" ] && [ ${OSHINKO_DEL_CLUSTER:-yes} == yes ]; then
         echo "Deleting cluster"
         $APP_ROOT/src/oshinko-get-cluster -delete -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME
     fi

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -52,7 +52,7 @@ then
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
 
 
-    if [ ${output[0]} == "creating" ] && [ ${OSHINKO_DEL_CLUSTER:-yes} == yes ]; then
+    if [ ${output[0]} == "creating" ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
         echo "Deleting cluster"
         $APP_ROOT/src/oshinko-get-cluster -delete -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME
     fi

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -29,7 +29,8 @@
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes"
+         "value": "yes",
+         "required": true
       },
       {
          "description": "Name of the main py file to run",

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -27,6 +27,11 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "yes"
+      },
+      {
          "description": "Name of the main py file to run",
          "name": "APP_FILE",
          "value": "app.py"
@@ -193,6 +198,10 @@
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",
                               "value": "true"
+                           },
+                           {
+                             "name": "OSHINKO_DEL_CLUSTER",
+                             "value": "${OSHINKO_DEL_CLUSTER}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -27,9 +27,9 @@
          "required": true
       },
       {
-         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes",
+         "value": "true",
          "required": true
       },
       {

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -32,6 +32,11 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "yes"
+      },
+      {
          "description": "Command line arguments to pass to the spark application",
          "name": "APP_ARGS"
       },
@@ -112,6 +117,10 @@
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",
                               "value": "true"
+                           },
+                           {
+                             "name": "OSHINKO_DEL_CLUSTER",
+                             "value": "${OSHINKO_DEL_CLUSTER}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -32,9 +32,9 @@
          "required": true
       },
       {
-         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes",
+         "value": "true",
          "required": true
       },
       {

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -34,7 +34,8 @@
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes"
+         "value": "yes",
+         "required": true
       },
       {
          "description": "Command line arguments to pass to the spark application",

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -34,7 +34,8 @@
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes"
+         "value": "yes",
+         "required": true
       },
       {
          "description": "Command line arguments to pass to the pyspark application",

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -32,6 +32,11 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "yes"
+      },
+      {
          "description": "Command line arguments to pass to the pyspark application",
          "name": "APP_ARGS"
       },
@@ -87,6 +92,10 @@
                                 {
                                    "name": "APP_MAIN_CLASS",
                                    "value": "${APP_MAIN_CLASS}"
+                                },
+                                {
+                                   "name": "OSHINKO_DEL_CLUSTER",
+                                   "value": "${OSHINKO_DEL_CLUSTER}"
                                 }
                               ]
                           }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -32,9 +32,9 @@
          "required": true
       },
       {
-         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'yes'",
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
-         "value": "yes",
+         "value": "true",
          "required": true
       },
       {

--- a/pyspark/s2i/bin/usage
+++ b/pyspark/s2i/bin/usage
@@ -25,7 +25,7 @@ optional environment variables which can be set when the application is launched
     OSHINKO_REST         -- ip of the oshinko-rest controller, required
     SPARK_OPTIONS        -- options to spark-submit, e.g.  "--conf spark.executor.memory=2G --conf spark.driver.memory=2G"
     APP_ARGS             -- arguments to the python application (if the app takes arguments)
-    OSHINKO_DEL_CLUSTER  -- if a new cluster is created and this flag is set to "yes" then the
+    OSHINKO_DEL_CLUSTER  -- if a new cluster is created and this flag is set to "true" then the
                             cluster will be deleted when the python application completes. The
                             default behavior is to leave the cluster.
 EOF


### PR DESCRIPTION
The oshinko app launcher supports deleting ephemeral clusters,
but the option was not exposed in the templates. This option
has been added and defaults to "yes". If a cluster is created
on-demand for an app, the cluster will be deleted when the app
completes unless the value is changed.