### PR TITLE
Move the random cluster name generation into the launcher.

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -6,6 +6,10 @@ echo "version 1"
 # This script is supplied by the python s2i base
 source $APP_ROOT/etc/generate_container_user
 
+if [ -z ${OSHINKO_CLUSTER_NAME} ]; then
+    OSHINKO_CLUSTER_NAME=cluster-`cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1`
+fi
+
 # Create the cluster through oshinko-rest if it does not exist
 # First line will say "creating" if it is creating the cluster
 # Second line will be the url of the spark master

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -20,11 +20,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "Name of the main py file to run",

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -25,11 +25,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "Command line arguments to pass to the spark application",

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -25,11 +25,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "Command line arguments to pass to the pyspark application",


### PR DESCRIPTION
Rather than generate the cluster name in the templates,
move the random generation into the start.sh script and
allow the cluster name to be blank in the templates.

This allows random cluster name generation to be used
from "oc new-app".

Also, increase the randomized portion to 6 characters.