### PR TITLE
Replace FROM_DEPLOYMENTCONFIG with APP_EXIT and default to false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: go
+
+services:
+  - docker
+
+script:
+  - docker build -f Dockerfile.pyspark .

--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -20,18 +20,26 @@ RUN cd /opt && \
         tar -zx && \
     ln -s spark-2.0.0-bin-hadoop2.7 spark
 
-ENV PATH=$PATH:/opt/spark/bin
-ENV SPARK_HOME=/opt/spark
+RUN yum install -y golang && \
+    yum clean all
+
+ENV GOPATH /go
+ADD . /go/src/github.com/radanalyticsio/oshinko-s2i
 
 # Default python file to run will be app.py but that may be
 # overridden at image build time
 ENV APP_ROOT /opt/app-root
 ENV APP_FILE app.py
 
-COPY ./utils/ $APP_ROOT/src
-RUN chown -R 1001:0 $APP_ROOT/src/*
+RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
+    make utils && \
+    cp utils/* $APP_ROOT/src && \
+    chown -R 1001:0 $APP_ROOT && \
+    chmod a+rwX -R $APP_ROOT && \
+    cp s2i/bin/* $STI_SCRIPTS_PATH
 
-COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+ENV PATH=$PATH:/opt/spark/bin
+ENV SPARK_HOME=/opt/spark
 
 USER 1001
 CMD $STI_SCRIPTS_PATH/usage

--- a/common/utils/README.md
+++ b/common/utils/README.md
@@ -19,10 +19,11 @@ spark-submit.
 
 Currently the script will sleep forever in a loop after submitting
 the spark application to prevent the process from exiting if the
-FROM_DEPLOYMENTCONFIG environment variable is set. This is to prevent
-a deploymentconfig from restarting the spark application after it
-completes (in general, a deploymentconfig may not be the best choice
-of openshift object for submitting a spark application)
+APP_EXIT environment variable is unset or set to "false". This is
+to prevent a deploymentconfig from restarting the spark application
+after it completes (in general, a deploymentconfig may not be the
+best choice of openshift object for submitting a spark application
+intended to run once to completion).
 
 ## environment variables ##
 

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -6,6 +6,10 @@ echo "version 1"
 # This script is supplied by the python s2i base
 source $APP_ROOT/etc/generate_container_user
 
+if [ -z ${OSHINKO_CLUSTER_NAME} ]; then
+    OSHINKO_CLUSTER_NAME=cluster-`cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1`
+fi
+
 # Create the cluster through oshinko-rest if it does not exist
 # First line will say "creating" if it is creating the cluster
 # Second line will be the url of the spark master

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -64,8 +64,7 @@ else
 fi
 
 # Sleep forever so the process does not complete
-if [ -n "${FROM_DEPLOYMENTCONFIG+x}" ]
-then
+if [ ${APP_EXIT:-false} == false ]; then
     while true
     do
         sleep 5

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -9,8 +9,7 @@ source $APP_ROOT/etc/generate_container_user
 # Create the cluster through oshinko-rest if it does not exist
 # First line will say "creating" if it is creating the cluster
 # Second line will be the url of the spark master
-# If OSHINKO_REST is defined it will be used, otherwise the env will be scanned to find the rest server
-output=($($APP_ROOT/src/oshinko-get-cluster -create -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME))
+output=($($APP_ROOT/src/oshinko-get-cluster -create $OSHINKO_CLUSTER_NAME))
 res=$?
 
 # Build the spark-submit command and execute
@@ -53,7 +52,7 @@ then
 
     if [ ${output[0]} == "creating" ] && [ "${OSHINKO_DEL_CLUSTER}" == "yes" ]; then
         echo "Deleting cluster"
-        $APP_ROOT/src/oshinko-get-cluster -delete -server=$OSHINKO_REST $OSHINKO_CLUSTER_NAME
+        $APP_ROOT/src/oshinko-get-cluster -delete $OSHINKO_CLUSTER_NAME
     fi
 else
     echo "$output"

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -50,7 +50,8 @@ then
     echo spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
 
-    if [ ${output[0]} == "creating" ] && [ "${OSHINKO_DEL_CLUSTER}" == "yes" ]; then
+
+    if [ ${output[0]} == "creating" ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
         echo "Deleting cluster"
         $APP_ROOT/src/oshinko-get-cluster -delete $OSHINKO_CLUSTER_NAME
     fi

--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -5,10 +5,13 @@ LOCAL_IMAGE=radanalytics-pyspark
 # "project" with an appropriate path for your registry and/or project
 PUSH_IMAGE=project/radanalytics-pyspark
 
+DOCKERFILE=../Dockerfile.pyspark
+DOCKERFILE_CONTEXT=..
+
 .PHONY: build clean push test
 
-build: utils
-	sudo docker build -t $(LOCAL_IMAGE) .
+build:
+	sudo docker build -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
 
 clean:
 	sudo docker rmi $(LOCAL_IMAGE)
@@ -23,5 +26,5 @@ utils:
 	cp -r ../common/utils .
 
 test:
-	docker build -t $(PUSH_IMAGE)-candidate .
+	docker build -t $(PUSH_IMAGE)-candidate -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
 	IMAGE_NAME=$(PUSH_IMAGE)-candidate test/run

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -54,6 +54,12 @@
          "description": "Git branch/tag reference",
          "name": "GIT_REF",
          "value": "master"
+      },
+      {
+         "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
+         "name": "APP_EXIT",
+         "value": "false",
+         "required": true
       }
    ],
    "objects": [
@@ -194,12 +200,11 @@
                               "value": "${APP_MAIN_CLASS}"
                            },
                            {
-                              "name": "FROM_DEPLOYMENTCONFIG",
-                              "value": "true"
-                           },
-                           {
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"
+                           },
+                           {  "name": "APP_EXIT",
+                              "value": "${APP_EXIT}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -27,6 +27,12 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "true",
+         "required": true
+      },
+      {
          "description": "Name of the main py file to run",
          "name": "APP_FILE",
          "value": "app.py"
@@ -193,6 +199,10 @@
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",
                               "value": "true"
+                           },
+                           {
+                             "name": "OSHINKO_DEL_CLUSTER",
+                             "value": "${OSHINKO_DEL_CLUSTER}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -20,11 +20,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -25,11 +25,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -45,8 +45,13 @@
       {
          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
+      },
+      {
+         "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
+         "name": "APP_EXIT",
+         "value": "false",
+         "required": true
       }
-
    ],
    "objects": [
       {
@@ -113,12 +118,12 @@
                               "value": "${APP_MAIN_CLASS}"
                            },
                            {
-                              "name": "FROM_DEPLOYMENTCONFIG",
-                              "value": "true"
-                           },
-                           {
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"
+                           },
+                           {
+                              "name": "APP_EXIT",
+                              "value": "${APP_EXIT}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -32,6 +32,12 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "true",
+         "required": true
+      },
+      {
          "description": "Command line arguments to pass to the spark application",
          "name": "APP_ARGS"
       },
@@ -112,6 +118,10 @@
                            {
                               "name": "FROM_DEPLOYMENTCONFIG",
                               "value": "true"
+                           },
+                           {
+                             "name": "OSHINKO_DEL_CLUSTER",
+                             "value": "${OSHINKO_DEL_CLUSTER}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -25,11 +25,8 @@
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against (it will be created if it does not exist)",
-         "name": "OSHINKO_CLUSTER_NAME",
-         "generate": "expression",
-         "from": "cluster-[a-z0-9]{4}",
-         "required": true
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -94,6 +94,10 @@
                                 {
                                    "name": "OSHINKO_DEL_CLUSTER",
                                    "value": "${OSHINKO_DEL_CLUSTER}"
+                                },
+                                {
+                                   "name": "APP_EXIT",
+                                   "value": "true"
                                 }
                               ]
                           }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -32,6 +32,12 @@
          "required": true
       },
       {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "true",
+         "required": true
+      },
+      {
          "description": "Command line arguments to pass to the pyspark application",
          "name": "APP_ARGS"
       },
@@ -87,6 +93,10 @@
                                 {
                                    "name": "APP_MAIN_CLASS",
                                    "value": "${APP_MAIN_CLASS}"
+                                },
+                                {
+                                   "name": "OSHINKO_DEL_CLUSTER",
+                                   "value": "${OSHINKO_DEL_CLUSTER}"
                                 }
                               ]
                           }

--- a/pyspark/s2i/bin/usage
+++ b/pyspark/s2i/bin/usage
@@ -28,4 +28,7 @@ optional environment variables which can be set when the application is launched
     OSHINKO_DEL_CLUSTER  -- if a new cluster is created and this flag is set to "true" then the
                             cluster will be deleted when the python application completes. The
                             default behavior is to leave the cluster.
+    APP_EXIT             -- if this value is unset or set to "false" then the script will
+                            loop forever after the spark application completes. To have the
+                            script exit, set this value to "true"
 EOF

--- a/pyspark/s2i/bin/usage
+++ b/pyspark/s2i/bin/usage
@@ -25,7 +25,7 @@ optional environment variables which can be set when the application is launched
     OSHINKO_REST         -- ip of the oshinko-rest controller, required
     SPARK_OPTIONS        -- options to spark-submit, e.g.  "--conf spark.executor.memory=2G --conf spark.driver.memory=2G"
     APP_ARGS             -- arguments to the python application (if the app takes arguments)
-    OSHINKO_DEL_CLUSTER  -- if a new cluster is created and this flag is set to "yes" then the
+    OSHINKO_DEL_CLUSTER  -- if a new cluster is created and this flag is set to "true" then the
                             cluster will be deleted when the python application completes. The
                             default behavior is to leave the cluster.
 EOF


### PR DESCRIPTION
The loop forever behavior is now controlled with the APP_EXIT
env var which is defaulted to "false" in start.sh if it is not
set. The APP_EXIT env var is set to "true" in the job template
but not exposed.  It is set to "false" in the deploymentconfig
templates and exposed so that it may be overridden.

This will allow the default behavior from "oc new-app" to be
application pods that never exit.  This behavior may be
overridden by passing "-e APP_EXIT=true" to oc new-app
(for a streaming app for example which should restart if
it ever exists)