### PR TITLE
Add python27-numpy into the radanalytics-pyspark base

### DIFF
--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -20,7 +20,7 @@ RUN cd /opt && \
         tar -zx && \
     ln -s spark-2.0.0-bin-hadoop2.7 spark
 
-RUN yum install -y golang && \
+RUN yum install -y golang python27-numpy && \
     yum clean all
 
 ENV GOPATH /go


### PR DESCRIPTION
Numpy is used commonly enough in pyspark apps that we should
add it into the base image.  Note that "python27-numpy" is
installed rather than "numpy" to match the packages included
in the python s2i base image from the centos-sclo-rh repo.