### PR TITLE
Use named configurations in oshinko-get-cluster

### DIFF
--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/clusters_client.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/clusters_client.go
@@ -37,7 +37,7 @@ func (a *Client) CreateCluster(params *CreateClusterParams) (*CreateClusterCreat
 		PathPattern:        "/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &CreateClusterReader{formats: a.formats},
 	})
@@ -62,7 +62,7 @@ func (a *Client) DeleteSingleCluster(params *DeleteSingleClusterParams) (*Delete
 		PathPattern:        "/clusters/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeleteSingleClusterReader{formats: a.formats},
 	})
@@ -87,7 +87,7 @@ func (a *Client) FindClusters(params *FindClustersParams) (*FindClustersOK, erro
 		PathPattern:        "/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &FindClustersReader{formats: a.formats},
 	})
@@ -112,7 +112,7 @@ func (a *Client) FindSingleCluster(params *FindSingleClusterParams) (*FindSingle
 		PathPattern:        "/clusters/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &FindSingleClusterReader{formats: a.formats},
 	})
@@ -137,7 +137,7 @@ func (a *Client) UpdateSingleCluster(params *UpdateSingleClusterParams) (*Update
 		PathPattern:        "/clusters/{name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &UpdateSingleClusterReader{formats: a.formats},
 	})

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/create_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/create_cluster_parameters.go
@@ -50,8 +50,8 @@ type CreateClusterParams struct {
 }
 
 // WithCluster adds the cluster to the create cluster params
-func (o *CreateClusterParams) WithCluster(Cluster *models.NewCluster) *CreateClusterParams {
-	o.Cluster = Cluster
+func (o *CreateClusterParams) WithCluster(cluster *models.NewCluster) *CreateClusterParams {
+	o.Cluster = cluster
 	return o
 }
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/create_cluster_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/create_cluster_responses.go
@@ -19,7 +19,7 @@ type CreateClusterReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *CreateClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
@@ -49,7 +49,7 @@ func NewCreateClusterCreated() *CreateClusterCreated {
 Cluster create response
 */
 type CreateClusterCreated struct {
-	/*URL of the cluster, this is oshinko specific
+	/*URL of the cluster detail page within the oshinko rest server
 	 */
 	Location string
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/delete_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/delete_single_cluster_parameters.go
@@ -48,8 +48,8 @@ type DeleteSingleClusterParams struct {
 }
 
 // WithName adds the name to the delete single cluster params
-func (o *DeleteSingleClusterParams) WithName(Name string) *DeleteSingleClusterParams {
-	o.Name = Name
+func (o *DeleteSingleClusterParams) WithName(name string) *DeleteSingleClusterParams {
+	o.Name = name
 	return o
 }
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/delete_single_cluster_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/delete_single_cluster_responses.go
@@ -19,7 +19,7 @@ type DeleteSingleClusterReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *DeleteSingleClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_clusters_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_clusters_responses.go
@@ -22,7 +22,7 @@ type FindClustersReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *FindClustersReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 
@@ -102,6 +102,58 @@ func (o *FindClustersDefault) readResponse(response runtime.ClientResponse, cons
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
+	}
+
+	return nil
+}
+
+/*FindClustersOKBodyBody find clusters o k body body
+
+swagger:model FindClustersOKBodyBody
+*/
+type FindClustersOKBodyBody struct {
+
+	/* clusters
+
+	Required: true
+	*/
+	Clusters []*ClustersItems0 `json:"clusters"`
+}
+
+// Validate validates this find clusters o k body body
+func (o *FindClustersOKBodyBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateClusters(formats); err != nil {
+		// prop
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *FindClustersOKBodyBody) validateClusters(formats strfmt.Registry) error {
+
+	if err := validate.Required("findClustersOK"+"."+"clusters", "body", o.Clusters); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(o.Clusters); i++ {
+
+		if swag.IsZero(o.Clusters[i]) { // not required
+			continue
+		}
+
+		if o.Clusters[i] != nil {
+
+			if err := o.Clusters[i].Validate(formats); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil
@@ -239,58 +291,6 @@ func (o *ClustersItems0) validateWorkerCount(formats strfmt.Registry) error {
 
 	if err := validate.Required("workerCount", "body", o.WorkerCount); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-/*FindClustersOKBodyBody find clusters o k body body
-
-swagger:model FindClustersOKBodyBody
-*/
-type FindClustersOKBodyBody struct {
-
-	/* clusters
-
-	Required: true
-	*/
-	Clusters []*ClustersItems0 `json:"clusters"`
-}
-
-// Validate validates this find clusters o k body body
-func (o *FindClustersOKBodyBody) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := o.validateClusters(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (o *FindClustersOKBodyBody) validateClusters(formats strfmt.Registry) error {
-
-	if err := validate.Required("findClustersOK"+"."+"clusters", "body", o.Clusters); err != nil {
-		return err
-	}
-
-	for i := 0; i < len(o.Clusters); i++ {
-
-		if swag.IsZero(o.Clusters[i]) { // not required
-			continue
-		}
-
-		if o.Clusters[i] != nil {
-
-			if err := o.Clusters[i].Validate(formats); err != nil {
-				return err
-			}
-		}
-
 	}
 
 	return nil

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_single_cluster_parameters.go
@@ -48,8 +48,8 @@ type FindSingleClusterParams struct {
 }
 
 // WithName adds the name to the find single cluster params
-func (o *FindSingleClusterParams) WithName(Name string) *FindSingleClusterParams {
-	o.Name = Name
+func (o *FindSingleClusterParams) WithName(name string) *FindSingleClusterParams {
+	o.Name = name
 	return o
 }
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_single_cluster_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/find_single_cluster_responses.go
@@ -19,7 +19,7 @@ type FindSingleClusterReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *FindSingleClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/update_single_cluster_parameters.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/update_single_cluster_parameters.go
@@ -55,14 +55,14 @@ type UpdateSingleClusterParams struct {
 }
 
 // WithCluster adds the cluster to the update single cluster params
-func (o *UpdateSingleClusterParams) WithCluster(Cluster *models.NewCluster) *UpdateSingleClusterParams {
-	o.Cluster = Cluster
+func (o *UpdateSingleClusterParams) WithCluster(cluster *models.NewCluster) *UpdateSingleClusterParams {
+	o.Cluster = cluster
 	return o
 }
 
 // WithName adds the name to the update single cluster params
-func (o *UpdateSingleClusterParams) WithName(Name string) *UpdateSingleClusterParams {
-	o.Name = Name
+func (o *UpdateSingleClusterParams) WithName(name string) *UpdateSingleClusterParams {
+	o.Name = name
 	return o
 }
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/update_single_cluster_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/clusters/update_single_cluster_responses.go
@@ -19,7 +19,7 @@ type UpdateSingleClusterReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *UpdateSingleClusterReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/oshinko_rest_client.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/oshinko_rest_client.go
@@ -21,7 +21,7 @@ func NewHTTPClient(formats strfmt.Registry) *OshinkoRest {
 	if formats == nil {
 		formats = strfmt.Default
 	}
-	transport := httptransport.New("localhost", "/", []string{"http"})
+	transport := httptransport.New("localhost", "/", []string{"https"})
 	return New(transport, formats)
 }
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/server/get_server_info_responses.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/server/get_server_info_responses.go
@@ -21,7 +21,7 @@ type GetServerInfoReader struct {
 	formats strfmt.Registry
 }
 
-// ReadResponse reads a server response into the recieved o.
+// ReadResponse reads a server response into the received o.
 func (o *GetServerInfoReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
 

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/server/server_client.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/client/server/server_client.go
@@ -37,7 +37,7 @@ func (a *Client) GetServerInfo(params *GetServerInfoParams) (*GetServerInfoOK, e
 		PathPattern:        "/",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
-		Schemes:            []string{"http"},
+		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetServerInfoReader{formats: a.formats},
 	})

--- a/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/models/new_cluster.go
+++ b/common/oshinko-get-cluster/vendor/github.com/radanalyticsio/oshinko-rest/models/new_cluster.go
@@ -5,6 +5,7 @@ package models
 
 import (
 	strfmt "github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/validate"
@@ -16,40 +17,27 @@ swagger:model NewCluster
 */
 type NewCluster struct {
 
-	/* The count of master nodes requested in the cluster
-
-	Required: true
-	*/
-	MasterCount *int64 `json:"masterCount"`
+	/* config
+	 */
+	Config *NewClusterConfig `json:"config,omitempty"`
 
 	/* Unique name for the cluster
 
 	Required: true
 	*/
 	Name *string `json:"name"`
-
-	/* The count of worker nodes requested in the cluster
-
-	Required: true
-	*/
-	WorkerCount *int64 `json:"workerCount"`
 }
 
 // Validate validates this new cluster
 func (m *NewCluster) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateMasterCount(formats); err != nil {
+	if err := m.validateConfig(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
 
 	if err := m.validateName(formats); err != nil {
-		// prop
-		res = append(res, err)
-	}
-
-	if err := m.validateWorkerCount(formats); err != nil {
 		// prop
 		res = append(res, err)
 	}
@@ -60,10 +48,17 @@ func (m *NewCluster) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *NewCluster) validateMasterCount(formats strfmt.Registry) error {
+func (m *NewCluster) validateConfig(formats strfmt.Registry) error {
 
-	if err := validate.Required("masterCount", "body", m.MasterCount); err != nil {
-		return err
+	if swag.IsZero(m.Config) { // not required
+		return nil
+	}
+
+	if m.Config != nil {
+
+		if err := m.Config.Validate(formats); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -78,11 +73,31 @@ func (m *NewCluster) validateName(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *NewCluster) validateWorkerCount(formats strfmt.Registry) error {
+/*NewClusterConfig Cluster configuration values
 
-	if err := validate.Required("workerCount", "body", m.WorkerCount); err != nil {
-		return err
+swagger:model NewClusterConfig
+*/
+type NewClusterConfig struct {
+
+	/* The count of master nodes requested in the cluster (must be > 0)
+	 */
+	MasterCount int64 `json:"masterCount,omitempty"`
+
+	/* The name of a stored cluster configuration
+	 */
+	Name interface{} `json:"name,omitempty"`
+
+	/* The count of worker nodes requested in the cluster (must be > 0)
+	 */
+	WorkerCount int64 `json:"workerCount,omitempty"`
+}
+
+// Validate validates this new cluster config
+func (m *NewClusterConfig) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
 	}
-
 	return nil
 }

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -6,7 +6,7 @@ echo "version 1"
 # This script is supplied by the python s2i base
 source $APP_ROOT/etc/generate_container_user
 
-if [ -z ${OSHINKO_CLUSTER_NAME} ]; then
+if [ -z "${OSHINKO_CLUSTER_NAME}" ]; then
     OSHINKO_CLUSTER_NAME=cluster-`cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1`
 fi
 
@@ -17,7 +17,11 @@ fi
 # The fourth line will be the url of the spark master webui
 # Split the output by line and store in an array
 SAVEIFS=$IFS; IFS=$'\n'
-output=($($APP_ROOT/src/oshinko-get-cluster -create -config $OSHINKO_NAMED_CONFIG $OSHINKO_CLUSTER_NAME))
+if [ -n "${OSHINKO_NAMED_CONFIG}" ]; then
+    output=($($APP_ROOT/src/oshinko-get-cluster -create -config $OSHINKO_NAMED_CONFIG $OSHINKO_CLUSTER_NAME))
+else
+    output=($($APP_ROOT/src/oshinko-get-cluster -create $OSHINKO_CLUSTER_NAME))
+fi
 res=$?
 
 # Build the spark-submit command and execute
@@ -58,7 +62,6 @@ then
     fi
     echo spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-
 
     if [ ${output[0]} == "creating" ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
         echo "Deleting cluster"

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -17,7 +17,7 @@ fi
 # The fourth line will be the url of the spark master webui
 # Split the output by line and store in an array
 SAVEIFS=$IFS; IFS=$'\n'
-output=($($APP_ROOT/src/oshinko-get-cluster -create $OSHINKO_CLUSTER_NAME))
+output=($($APP_ROOT/src/oshinko-get-cluster -create -config $OSHINKO_NAMED_CONFIG $OSHINKO_CLUSTER_NAME))
 res=$?
 
 # Build the spark-submit command and execute

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -24,7 +24,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -24,6 +24,10 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
+         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
@@ -205,6 +209,10 @@
                            },
                            {  "name": "APP_EXIT",
                               "value": "${APP_EXIT}"
+                           },
+                           {
+                              "name": "OSHINKO_NAMED_CONFIG",
+                              "value": "${OSHINKO_NAMED_CONFIG}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -29,6 +29,10 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
+         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
@@ -124,6 +128,10 @@
                            {
                               "name": "APP_EXIT",
                               "value": "${APP_EXIT}"
+                           },
+                           {
+                              "name": "OSHINKO_NAMED_CONFIG",
+                              "value": "${OSHINKO_NAMED_CONFIG}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -29,7 +29,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -29,6 +29,10 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
+         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
@@ -98,6 +102,10 @@
                                 {
                                    "name": "APP_EXIT",
                                    "value": "true"
+                                },
+                                {
+                                   "name": "OSHINKO_NAMED_CONFIG",
+                                   "value": "${OSHINKO_NAMED_CONFIG}"
                                 }
                               ]
                           }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -29,7 +29,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a stored cluster configuration to use for this cluster, default is 'default'",
+         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {


### PR DESCRIPTION
This change allows oshinko-get-cluster to accept the name of
a configuration and pass it to oshinko for cluster creation.
If no name is specified, the default configuration will be
used by oshinko.