### PR TITLE
Change the order of objects in the pyspark build templates.

### DIFF
--- a/pyspark/pysparkbuild.json
+++ b/pyspark/pysparkbuild.json
@@ -36,6 +36,21 @@
    ],
    "objects": [
       {
+         "kind": "ImageStream",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}"
+         },
+         "spec": {
+            "dockerImageRepository": "${APPLICATION_NAME}",
+            "tags": [
+               {
+                  "name": "latest"
+               }
+            ]
+         }
+      },
+      {
          "kind": "BuildConfig",
          "apiVersion": "v1",
          "metadata": {
@@ -91,21 +106,6 @@
                   "name": "${APPLICATION_NAME}:latest"
                }
             }
-         }
-      },
-      {
-         "kind": "ImageStream",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "dockerImageRepository": "${APPLICATION_NAME}",
-            "tags": [
-               {
-                  "name": "latest"
-               }
-            ]
          }
       }
    ]

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -68,6 +68,21 @@
    ],
    "objects": [
       {
+         "kind": "ImageStream",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}"
+         },
+         "spec": {
+            "dockerImageRepository": "${APPLICATION_NAME}",
+            "tags": [
+               {
+                  "name": "latest"
+               }
+            ]
+         }
+      },
+      {
          "kind": "BuildConfig",
          "apiVersion": "v1",
          "metadata": {
@@ -123,21 +138,6 @@
                   "name": "${APPLICATION_NAME}:latest"
                }
             }
-         }
-      },
-      {
-         "kind": "ImageStream",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "dockerImageRepository": "${APPLICATION_NAME}",
-            "tags": [
-               {
-                  "name": "latest"
-               }
-            ]
          }
       },
       {


### PR DESCRIPTION
Creating the imagestream after the buildconfig can result
in a race condition where the build does not have credentials
to push the image to the imagestream when the build completes
(based on feedback from openshift devs and confirmed anectdotally).