### PR TITLE
Make s2i templates pull radanalytics-pyspark public image

### DIFF
--- a/pyspark/pysparkbuild.json
+++ b/pyspark/pysparkbuild.json
@@ -74,8 +74,8 @@
                "type": "Source",
                "sourceStrategy": {
                   "from": {
-                     "kind": "ImageStreamTag",
-                     "name": "radanalytics-pyspark:latest"
+                     "kind": "DockerImage",
+                     "name": "radanalyticsio/radanalytics-pyspark"
                   },
                   "env": [
                      {

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -106,8 +106,8 @@
                "type": "Source",
                "sourceStrategy": {
                   "from": {
-                     "kind": "ImageStreamTag",
-                     "name": "radanalytics-pyspark:latest"
+                     "kind": "DockerImage",
+                     "name": "radanalyticsio/radanalytics-pyspark"
                   },
                   "env": [
                      {


### PR DESCRIPTION
This commit changes how the image for the builder is specified
and will cause openshift to pull the radanalytics-pyspark
public image instead of a local imagestream. This behavior
matches the default for the other oshinko/spark images.