### PR TITLE
Simplify the pyspark templates

### DIFF
--- a/pyspark/pysparkbuild.json
+++ b/pyspark/pysparkbuild.json
@@ -20,9 +20,8 @@
          "required": true
       },
       {
-         "description": "Name of the main py file to run",
-         "name": "APP_FILE",
-         "value": "app.py"
+         "description": "The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.",
+         "name": "APP_FILE"
       },
       {
          "description": "Git source URI for application",

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -34,17 +34,12 @@
          "required": true
       },
       {
-         "description": "Name of the main py file to run",
-         "name": "APP_FILE",
-         "value": "app.py"
+         "description": "The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.",
+         "name": "APP_FILE"
       },
       {
          "description": "Command line arguments to pass to the spark application",
          "name": "APP_ARGS"
-      },
-      {
-         "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS"
       },
       {
           "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
@@ -199,10 +194,6 @@
                               "name": "SPARK_OPTIONS",
                                "value": "${SPARK_OPTIONS}"
 			   },
-                           {
-                              "name": "APP_MAIN_CLASS",
-                              "value": "${APP_MAIN_CLASS}"
-                           },
                            {
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -43,10 +43,6 @@
          "name": "APP_ARGS"
       },
       {
-         "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS"
-      },
-      {
          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       },
@@ -116,10 +112,6 @@
                            {
                               "name": "SPARK_OPTIONS",
                               "value": "${SPARK_OPTIONS}"
-                           },
-                           {
-                              "name": "APP_MAIN_CLASS",
-                              "value": "${APP_MAIN_CLASS}"
                            },
                            {
                              "name": "OSHINKO_DEL_CLUSTER",


### PR DESCRIPTION
* remove APP_MAIN_CLASS from the spark templates in light of java templates
* make APP_FILE settable on builds but blank by default