### PR TITLE
Use a ConfigMap for spark driver configuration

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -41,7 +41,22 @@ then
     fi
 fi
 
-# Set up the env for the spark user
+# Determine SPARK_CONF_DIR. If a non-empty config has been given then use it
+ls -1 /etc/oshinko-spark-configs &> /dev/null
+if [ $? -eq 0 ]
+then
+    sparkconfs=$(ls -1 /etc/oshinko-spark-configs | wc -l)
+    if [ "${sparkconfs}" -ne "0" ]
+    then
+        echo "Setting SPARK_CONF_DIR to /etc/oshinko-spark-configs"
+        export SPARK_CONF_DIR=/etc/oshinko-spark-configs
+    else
+        echo "/etc/oshinko-spark-configs is empty, using default SPARK_CONF_DIR"
+    fi
+else
+    echo "/etc/oshinko-spark-configs does not exist, using default SPARK_CONF_DIR"
+fi
+
 # This script is supplied by the python s2i base
 source $APP_ROOT/etc/generate_container_user
 

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -24,8 +24,14 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
+         "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
+         "value": "oshinko-spark-driver-config",
+         "required": true
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
@@ -217,11 +223,26 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always"
+                        "imagePullPolicy": "Always",
+                        "volumeMounts": [
+                           {
+                              "mountPath": "/etc/oshinko-spark-configs",
+                              "name": "spark-driver-config",
+                              "readOnly": true
+                           }
+                        ]
                      }
                   ],
                   "restartPolicy": "Always",
-                  "dnsPolicy": "ClusterFirst"
+                  "dnsPolicy": "ClusterFirst",
+                  "volumes": [
+                      {
+                          "name": "spark-driver-config",
+                          "configMap": {
+                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
+                          }
+                      }
+                  ]
                }
             }
          }

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -29,9 +29,16 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
       },
+      {
+        "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+        "name": "OSHINKO_SPARK_DRIVER_CONFIG",
+        "value": "oshinko-spark-driver-config",
+        "required": true
+      },
+
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
@@ -136,11 +143,27 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always"
+                        "imagePullPolicy": "Always",
+                        "volumeMounts": [
+                           {
+                              "mountPath": "/etc/oshinko-spark-configs",
+                              "name": "spark-driver-config",
+                              "readOnly": true
+                           }
+                        ]
                      }
                   ],
                   "restartPolicy": "Always",
-                  "dnsPolicy": "ClusterFirst"
+                  "dnsPolicy": "ClusterFirst",
+                  "volumes": [
+                      {
+                          "name": "spark-driver-config",
+                          "configMap": {
+                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
+                          }
+                      }
+                  ]
+
                }
             }
          }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -29,10 +29,17 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
+         "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
+         "value": "oshinko-spark-driver-config",
+         "required": true
+      },
+      {
+
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
@@ -107,10 +114,25 @@
                                    "name": "OSHINKO_NAMED_CONFIG",
                                    "value": "${OSHINKO_NAMED_CONFIG}"
                                 }
+                              ],
+                              "volumeMounts": [
+                                 {
+                                    "mountPath": "/etc/oshinko-spark-configs",
+                                    "name": "spark-driver-config",
+                                    "readOnly": true
+                                 }
                               ]
                           }
                       ],
-                      "restartPolicy": "Never"
+                      "restartPolicy": "Never",
+                      "volumes": [
+                          {
+                              "name": "spark-driver-config",
+                              "configMap": {
+                                  "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
+                              }
+                          }
+                      ]
                   }
               }
           }


### PR DESCRIPTION
The pyspark templates will mount a ConfigMap on
the driver pod which contains a spark configuration.
By default, it will mount an empty ConfigMap created
by oshinko but the name of another ConfigMap may be
specified in the template. If the start.sh script sees
a non-empty ConfigMap mounted in the container at a
well-known location it will use that spark configuration.