### PR TITLE
Add forcePull for pyspark images

### DIFF
--- a/java/javabuild.json
+++ b/java/javabuild.json
@@ -73,9 +73,10 @@
                "type": "Source",
                "sourceStrategy": {
                   "from": {
-                     "kind": "ImageStreamTag",
-                     "name": "radanalytics-java-spark:latest"
+                     "kind": "ImageStream",
+                     "name": "radanalytics-java-spark"
                   },
+                  "forcePull": true,
                   "env": [
                      {
                         "name": "APP_FILE",

--- a/java/javabuilddc.json
+++ b/java/javabuilddc.json
@@ -106,9 +106,10 @@
                "type": "Source",
                "sourceStrategy": {
                   "from": {
-                     "kind": "ImageStreamTag",
-                     "name": "radanalytics-java-spark:latest"
+                     "kind": "ImageStream",
+                     "name": "radanalytics-java-spark"
                   },
+                  "forcePull": true,
                   "env": [
                      {
                         "name": "APP_FILE",

--- a/pyspark/pysparkbuild.json
+++ b/pyspark/pysparkbuild.json
@@ -91,6 +91,7 @@
                      "kind": "DockerImage",
                      "name": "radanalyticsio/radanalytics-pyspark"
                   },
+                  "forcePull": true,
                   "env": [
                      {
                         "name": "APP_FILE",

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -119,6 +119,7 @@
                      "kind": "DockerImage",
                      "name": "radanalyticsio/radanalytics-pyspark"
                   },
+                  "forcePull": true,
                   "env": [
                      {
                         "name": "APP_FILE",


### PR DESCRIPTION
We need forcePull set to true in the build config source strategy
for the pyspark images in order to insure that we
get the latest image.