### PR TITLE
Change the description of the OSHINKO_NAMED_CONFIG param

### DIFF
--- a/java/javabuilddc.json
+++ b/java/javabuilddc.json
@@ -24,7 +24,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
+         "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/java/javabuilddc.json
+++ b/java/javabuilddc.json
@@ -24,7 +24,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for this cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+         "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -24,11 +24,11 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
          "name": "OSHINKO_SPARK_DRIVER_CONFIG",
          "value": "oshinko-spark-driver-config",
          "required": true

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -24,7 +24,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
+	  "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -29,7 +29,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
+	  "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -29,11 +29,11 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-        "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+        "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
         "value": "oshinko-spark-driver-config",
         "required": true

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -28,12 +28,12 @@
          "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
          "name": "OSHINKO_CLUSTER_NAME"
       },
-      {
-         "description": "The name of a configuration to use for a newly created spark cluster, default is 'default'. The list of named configurations is stored in the configmap 'oshinko-cluster-configs'" ,
+       {
+	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a ConfigMap to use for the spark configuration of the driver. If this ConfigMap is empty the default spark configuration will be used.",
+         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
          "name": "OSHINKO_SPARK_DRIVER_CONFIG",
          "value": "oshinko-spark-driver-config",
          "required": true

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -29,7 +29,7 @@
          "name": "OSHINKO_CLUSTER_NAME"
       },
        {
-	  "description": "The name of a configuration to use for this cluster, default is 'default'. Each configuration is stored in a configmap with a matching name.",
+	  "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {


### PR DESCRIPTION
The description mentioned oshinko-cluster-configs, but
that configmap is no longer used (naemd configs are
read directly)