### PR TITLE
Fix exit code on app_exit

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -10,7 +10,7 @@ function app_exit {
             sleep 5
         done
     else
-        exit
+        exit 0
     fi
 }
 


### PR DESCRIPTION
The app_exit function needs to return 0, otherwise the
return code will cause kubernetes jobs to run repeatedly.