### PR TITLE
Use the cli to dynamically retrieve driver spark config

### DIFF
--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -36,7 +36,10 @@ RUN mkdir -p $APP_ROOT/src && mkdir $APP_ROOT/etc && \
     cp generate_container_user $APP_ROOT/etc && \
     chown -R 1001:0 $APP_ROOT && \
     chmod a+rwX -R $APP_ROOT && \
-    cp s2i/bin/* /usr/local/s2i
+    cp s2i/bin/* /usr/local/s2i && \
+    chown -R 1001:0 /opt/spark/conf && \
+    chmod g+rw -R /opt/spark/conf && \
+    rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i/common/oshinko-cli
 
 ENV PATH=$PATH:/opt/spark/bin
 ENV SPARK_HOME=/opt/spark

--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -36,7 +36,11 @@ RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
     cp utils/* $APP_ROOT/src && \
     chown -R 1001:0 $APP_ROOT && \
     chmod a+rwX -R $APP_ROOT && \
-    cp s2i/bin/* $STI_SCRIPTS_PATH
+    cp s2i/bin/* $STI_SCRIPTS_PATH && \
+    chown -R 1001:0 /opt/spark/conf && \
+    chmod g+rw -R /opt/spark/conf && \
+    rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i/common/oshinko-cli
+    
 
 ENV PATH=$PATH:/opt/spark/bin
 ENV SPARK_HOME=/opt/spark

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,7 +1,7 @@
 build: CMD=build
 clean: CMD=clean
 
-.PHONY: oshinko-clix process-driver-config
+.PHONY: oshinko-cli process-driver-config
 
 export GOPATH = $(CURDIR)/oshinko-cli
 clonepath = $(CURDIR)/oshinko-cli/src/github.com/radanalyticsio
@@ -11,19 +11,19 @@ makepath = $(clonepath)/oshinko-cli
 # by other components, so handle it here rather than give it
 # a Makefile which we would want to exclude on a copy
 
-build: oshinko-clix process-driver-config
-	cp $(makepath)/_output/oshinko-clix utils
+build: oshinko-cli process-driver-config
+	cp $(makepath)/_output/oshinko-cli utils
 	cp process-driver-config/process-driver-config utils
 
 clean: 
-	rm -f utils/oshinko-clix
+	rm -f utils/oshinko-cli
 	rm -f utils/process-driver-config
 	rm -rf $(clonepath)
 
-oshinko-clix:
+oshinko-cli:
 	- mkdir -p $(clonepath)
 	- cd $(clonepath) && git clone https://github.com/radanalyticsio/oshinko-cli
-	cd $(makepath) && make build-extended
+	cd $(makepath) && make extended
 
 process-driver-config:
 	unset GOPATH

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,7 +1,7 @@
 build: CMD=build
 clean: CMD=clean
 
-.PHONY: oshinko-cli
+.PHONY: oshinko-clix process-driver-config
 
 export GOPATH = $(CURDIR)/oshinko-cli
 clonepath = $(CURDIR)/oshinko-cli/src/github.com/radanalyticsio
@@ -11,14 +11,20 @@ makepath = $(clonepath)/oshinko-cli
 # by other components, so handle it here rather than give it
 # a Makefile which we would want to exclude on a copy
 
-build: oshinko-cli
-	cp $(makepath)/_output/oshinko-cli utils
+build: oshinko-clix process-driver-config
+	cp $(makepath)/_output/oshinko-clix utils
+	cp process-driver-config/process-driver-config utils
 
 clean: 
-	rm -f utils/oshinko-cli
+	rm -f utils/oshinko-clix
+	rm -f utils/process-driver-config
 	rm -rf $(clonepath)
 
-oshinko-cli:
+oshinko-clix:
 	- mkdir -p $(clonepath)
 	- cd $(clonepath) && git clone https://github.com/radanalyticsio/oshinko-cli
-	cd $(makepath) && make build
+	cd $(makepath) && make build-extended
+
+process-driver-config:
+	unset GOPATH
+	cd process-driver-config && go build

--- a/common/process-driver-config/process-driver-config.go
+++ b/common/process-driver-config/process-driver-config.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+        "encoding/json"
+	"io/ioutil"
+	"path/filepath"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) != 1 {
+		fmt.Println("error, missing argument")
+		os.Exit(-1)
+	}
+	bytes, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(-1)
+	}
+	var data map[string]interface{}
+	err = json.Unmarshal(bytes, &data)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(-1)
+	}
+
+	if val, ok := data["data"]; ok {
+		configs, ok := val.(map[string]interface{})
+		if !ok {
+			fmt.Println("configmap data is not a set of key/value pairs")
+			os.Exit(-1)
+		}
+		directory := os.Getenv("SPARK_HOME")
+		if directory != "" {
+			directory = filepath.Join(directory, "conf")
+		}
+		for k, v := range configs {
+			txt, ok := v.(string)
+			if ok {
+				file, err := os.Create(filepath.Join(directory, k))
+				if err == nil {
+					fmt.Printf("Writing %s\n", filepath.Join(directory, k))
+					file.WriteString(txt)
+				} else {
+					fmt.Println(err.Error())
+					fmt.Printf("Could not write %s\n", filepath.Join(directory, k))
+				}
+			}
+		}
+	}
+}

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -45,7 +45,7 @@ if [ -z "${OSHINKO_CLUSTER_NAME}" ]; then
 fi
 
 # Create the cluster through oshinko-cli if it does not exist
-CLI=$APP_ROOT/src/oshinko-clix
+CLI=$APP_ROOT/src/oshinko-cli
 CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 KUBE="$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
 SA=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`

--- a/java/javabuilddc.json
+++ b/java/javabuilddc.json
@@ -28,6 +28,10 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
+         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
+      },
+      {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
@@ -214,6 +218,10 @@
                            {
                               "name": "OSHINKO_NAMED_CONFIG",
                               "value": "${OSHINKO_NAMED_CONFIG}"
+                           },
+                           {
+                              "name": "OSHINKO_SPARK_DRIVER_CONFIG",
+                              "value": "${OSHINKO_SPARK_DRIVER_CONFIG}"
                            }
                         ],
                         "resources": {},

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -29,9 +29,7 @@
       },
       {
          "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-         "value": "oshinko-spark-driver-config",
-         "required": true
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
@@ -211,31 +209,20 @@
                            {
                               "name": "OSHINKO_NAMED_CONFIG",
                               "value": "${OSHINKO_NAMED_CONFIG}"
+                           },
+                           {
+                              "name": "OSHINKO_SPARK_DRIVER_CONFIG",
+                              "value": "${OSHINKO_SPARK_DRIVER_CONFIG}"
                            }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
-                        "volumeMounts": [
-                           {
-                              "mountPath": "/etc/oshinko-spark-configs",
-                              "name": "spark-driver-config",
-                              "readOnly": true
-                           }
-                        ]
+                        "imagePullPolicy": "Always"
                      }
                   ],
                   "restartPolicy": "Always",
                   "serviceAccount": "oshinko",
-                  "dnsPolicy": "ClusterFirst",
-                  "volumes": [
-                      {
-                          "name": "spark-driver-config",
-                          "configMap": {
-                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                          }
-                      }
-                  ]
+                  "dnsPolicy": "ClusterFirst"
                }
             }
          }

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -34,11 +34,8 @@
       },
       {
         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-        "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-        "value": "oshinko-spark-driver-config",
-        "required": true
+        "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
-
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
@@ -135,28 +132,12 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
-                        "volumeMounts": [
-                           {
-                              "mountPath": "/etc/oshinko-spark-configs",
-                              "name": "spark-driver-config",
-                              "readOnly": true
-                           }
-                        ]
+                        "imagePullPolicy": "Always"
                      }
                   ],
                   "restartPolicy": "Always",
                   "serviceAccount": "oshinko",
-                  "dnsPolicy": "ClusterFirst",
-                  "volumes": [
-                      {
-                          "name": "spark-driver-config",
-                          "configMap": {
-                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                          }
-                      }
-                  ]
-
+                  "dnsPolicy": "ClusterFirst"
                }
             }
          }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -34,9 +34,7 @@
       },
       {
          "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-         "value": "oshinko-spark-driver-config",
-         "required": true
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
 
@@ -114,26 +112,11 @@
                                    "name": "OSHINKO_NAMED_CONFIG",
                                    "value": "${OSHINKO_NAMED_CONFIG}"
                                 }
-                              ],
-                              "volumeMounts": [
-                                 {
-                                    "mountPath": "/etc/oshinko-spark-configs",
-                                    "name": "spark-driver-config",
-                                    "readOnly": true
-                                 }
                               ]
                           }
                       ],
                       "restartPolicy": "Never",
-                      "serviceAccount": "oshinko",
-                      "volumes": [
-                          {
-                              "name": "spark-driver-config",
-                              "configMap": {
-                                  "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                              }
-                          }
-                      ]
+                      "serviceAccount": "oshinko"
                   }
               }
           }


### PR DESCRIPTION
This change uses an extended oshinko CLI to
check for the existence of a specified configmap at application
launch time. If this configmap exists, the files it contains
will be written to $SPARK_HOME/conf to update the spark
configuration of the driver.

This replaces an impl that used a volume mount to modify the
spark driver config.