### PR TITLE
Remove use of configmap volume for driver spark config

### DIFF
--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -28,10 +28,8 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-         "value": "oshinko-spark-driver-config",
-         "required": true
+         "description": "The name of a configmap to use for the spark configuration of the driver.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
@@ -215,27 +213,12 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
-                        "volumeMounts": [
-                           {
-                              "mountPath": "/etc/oshinko-spark-configs",
-                              "name": "spark-driver-config",
-                              "readOnly": true
-                           }
-                        ]
+                        "imagePullPolicy": "Always"
                      }
                   ],
                   "restartPolicy": "Always",
                   "serviceAccount": "oshinko",
-                  "dnsPolicy": "ClusterFirst",
-                  "volumes": [
-                      {
-                          "name": "spark-driver-config",
-                          "configMap": {
-                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                          }
-                      }
-                  ]
+                  "dnsPolicy": "ClusterFirst"
                }
             }
          }

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -33,12 +33,9 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-        "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
+        "description": "The name of a configmap to use for the spark configuration of the driver.",
         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-        "value": "oshinko-spark-driver-config",
-        "required": true
       },
-
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
@@ -135,28 +132,12 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
-                        "volumeMounts": [
-                           {
-                              "mountPath": "/etc/oshinko-spark-configs",
-                              "name": "spark-driver-config",
-                              "readOnly": true
-                           }
-                        ]
+                        "imagePullPolicy": "Always"
                      }
                   ],
                   "restartPolicy": "Always",
                   "serviceAccount": "oshinko",
-                  "dnsPolicy": "ClusterFirst",
-                  "volumes": [
-                      {
-                          "name": "spark-driver-config",
-                          "configMap": {
-                              "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                          }
-                      }
-                  ]
-
+                  "dnsPolicy": "ClusterFirst"
                }
             }
          }

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -39,10 +39,8 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG",
-         "value": "oshinko-spark-driver-config",
-         "required": true
+         "description": "The name of a configmap to use for the spark configuration of the driver.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
 
@@ -120,26 +118,11 @@
                                    "name": "OSHINKO_NAMED_CONFIG",
                                    "value": "${OSHINKO_NAMED_CONFIG}"
                                 }
-                              ],
-                              "volumeMounts": [
-                                 {
-                                    "mountPath": "/etc/oshinko-spark-configs",
-                                    "name": "spark-driver-config",
-                                    "readOnly": true
-                                 }
                               ]
                           }
                       ],
                       "restartPolicy": "Never",
-                      "serviceAccount": "oshinko",
-                      "volumes": [
-                          {
-                              "name": "spark-driver-config",
-                              "configMap": {
-                                  "name": "${OSHINKO_SPARK_DRIVER_CONFIG}"
-                              }
-                          }
-                      ]
+                      "serviceAccount": "oshinko"
                   }
               }
           }


### PR DESCRIPTION
The spark configuration for the driver pod used to be
supplied through a configmap volume. However, now the configmap
is read dynamically and the contents written to the spark conf
dir. This also removes the need for the oshinko-spark-driver-config
empty configmap that acted as a placeholder.