### PR TITLE
Copy user spark configuration to $SPARK_HOME/conf on start

### DIFF
--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -39,7 +39,6 @@ RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
     chown -R 1001:0 /opt/spark/conf && \
     chmod -R g+rw /opt/spark/conf && \
     rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i/common/oshinko-cli
-    
 
 ENV PATH=$PATH:/opt/spark/bin
 ENV SPARK_HOME=/opt/spark

--- a/java/s2i/bin/run
+++ b/java/s2i/bin/run
@@ -7,4 +7,14 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
+if [ -d $APP_ROOT/src/spark-conf ]; then
+    sparkconfs=$(ls -1 $APP_ROOT/src/spark-conf | wc -l)
+    if [ "$sparkconfs" -ne "0" ]; then
+        echo "Spark configuration included with application source"
+        echo "Copying from $APP_ROOT/src/spark-conf to $SPARK_HOME/conf"
+        ls -1 $APP_ROOT/src/spark-conf
+        cp $APP_ROOT/src/spark-conf/* $SPARK_HOME/conf
+    fi
+fi
+
 $APP_ROOT/src/start.sh

--- a/pyspark/s2i/bin/run
+++ b/pyspark/s2i/bin/run
@@ -7,4 +7,14 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
+if [ -d $APP_ROOT/src/spark-conf ]; then
+    sparkconfs=$(ls -1 $APP_ROOT/src/spark-conf | wc -l)
+    if [ "$sparkconfs" -ne "0" ]; then
+        echo "Spark configuration included with application source"
+        echo "Copying from $APP_ROOT/src/spark-conf to $SPARK_HOME/conf"
+        ls -1 $APP_ROOT/src/spark-conf
+        cp $APP_ROOT/src/spark-conf/* $SPARK_HOME/conf
+    fi
+fi
+
 $APP_ROOT/src/start.sh


### PR DESCRIPTION
If the user source git contains a "spark-conf" directory,
then copy the contents to $SPARK_HOME/conf in the run
script before the startup script is called. This gives the
user the option to update the spark configuration for the
driver via the git repository.