### PR TITLE
Modify how permissions are set in light of base image changes

### DIFF
--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -33,12 +33,11 @@ ENV APP_FILE app.py
 
 RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
     make utils && \
-    cp utils/* $APP_ROOT/src && \
-    chown -R 1001:0 $APP_ROOT && \
-    chmod a+rwX -R $APP_ROOT && \
+    chown -R 1001:0 utils/* && \
+    cp -rp utils/* $APP_ROOT/src && \
     cp s2i/bin/* $STI_SCRIPTS_PATH && \
     chown -R 1001:0 /opt/spark/conf && \
-    chmod g+rw -R /opt/spark/conf && \
+    chmod -R g+rw /opt/spark/conf && \
     rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i/common/oshinko-cli
     
 


### PR DESCRIPTION
The python27 s2i base image assemble now runs scripts
on /opt/app-root to set permissions correctly so Dockerfile.pyspark
does not need to do that explicitly. Remove the settings here for
clarity and let the base image scripts handle it.