### PR TITLE
Add --pull to local image build target

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -11,7 +11,7 @@ DOCKERFILE_CONTEXT=..
 .PHONY: build clean push test
 
 build:
-	sudo docker build -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
+	sudo docker build --pull -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
 
 clean:
 	- sudo docker rmi $(LOCAL_IMAGE)

--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -11,7 +11,7 @@ DOCKERFILE_CONTEXT=..
 .PHONY: build clean push test
 
 build:
-	sudo docker build -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
+	sudo docker build --pull -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
 
 clean:
 	sudo docker rmi $(LOCAL_IMAGE)


### PR DESCRIPTION
Builds of images using the Makefile should always look
for a newer version of the base image than what might
be locally cached.