### PR TITLE
Pull a specific tag of the oshinko-cli when building

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -22,7 +22,7 @@ clean:
 
 oshinko-cli:
 	- mkdir -p $(clonepath)
-	- cd $(clonepath) && git clone https://github.com/radanalyticsio/oshinko-cli
+	- cd $(clonepath) && git clone -b v0.1.0 https://github.com/radanalyticsio/oshinko-cli
 	cd $(makepath) && make extended
 
 process-driver-config:


### PR DESCRIPTION
This change causes the s2i images to pull a specific
tagged version of the oshinko-cli source code when building
the image. Previously the tip of master would always be
pulled. Adding the tag also gives us a way to trigger
a build of the s2i images with a git commit.