### PR TITLE
Remove the -f flag on docker tag

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -18,7 +18,7 @@ clean:
 	rm -rf utils
 
 push: build
-	sudo docker tag -f $(LOCAL_IMAGE) $(PUSH_IMAGE)
+	sudo docker tag $(LOCAL_IMAGE) $(PUSH_IMAGE)
 	sudo docker push $(PUSH_IMAGE)
 
 utils:

--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -18,7 +18,7 @@ clean:
 	rm -rf utils
 
 push: build
-	sudo docker tag -f $(LOCAL_IMAGE) $(PUSH_IMAGE)
+	sudo docker tag $(LOCAL_IMAGE) $(PUSH_IMAGE)
 	sudo docker push $(PUSH_IMAGE)
 
 utils:


### PR DESCRIPTION
The --force flag has been deprecated for a while, docker 1.12
which is wanted by origin 1.4 makes it an error.  Remove the -f
flag from the Makefile (folks using it against older versions
of docker will have to adjust).