### PR TITLE
Add the --namespace flag on CLI commands in start.sh

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -22,7 +22,7 @@ clean:
 
 oshinko-cli:
 	- mkdir -p $(clonepath)
-	- cd $(clonepath) && git clone -b v0.2.0 https://github.com/radanalyticsio/oshinko-cli
+	- cd $(clonepath) && git clone -b v0.2.1 https://github.com/radanalyticsio/oshinko-cli
 	cd $(makepath) && make extended
 
 process-driver-config:

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -49,7 +49,8 @@ CLI=$APP_ROOT/src/oshinko-cli
 CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 KUBE="$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT"
 SA=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
-CLI_ARGS="--certificate-authority=$CA --server=$KUBE --token=$SA"
+NS=`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`
+CLI_ARGS="--certificate-authority=$CA --server=$KUBE --token=$SA --namespace=$NS"
 CREATED=false
 
 # If a spark driver configmap has been named, use the cli to get it


### PR DESCRIPTION
The startup script can always get the current namespace from
/var/run/secrets, so pass it in on all commands. This allows
the CLI to accurately return errors that occur when the token
being used does not have adequate permissions (rather than
report errors on namespace itself which may be undeterminable
when the token is not privileged)