### PR TITLE
Add default spark configs to driver that match openshift-spark

### DIFF
--- a/Dockerfile.java
+++ b/Dockerfile.java
@@ -26,6 +26,7 @@ RUN yum install -y golang make nss_wrapper git gcc \
 
 ENV GOPATH /go
 ADD . /go/src/github.com/radanalyticsio/oshinko-s2i
+ADD ./common/spark-conf/* /opt/spark/conf/
 
 ENV APP_ROOT /opt/app-root
 

--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -23,6 +23,7 @@ RUN cd /opt && \
 RUN yum install -y golang && yum clean all
 
 ADD . /go/src/github.com/radanalyticsio/oshinko-s2i
+ADD ./common/spark-conf/* /opt/spark/conf/
 
 RUN cp /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark/s2i/bin/* $STI_SCRIPTS_PATH && \
     chmod -R g+rw /opt/spark/conf && \

--- a/common/spark-conf/log4j.properties
+++ b/common/spark-conf/log4j.properties
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark_project.jetty=WARN
+log4j.logger.org.spark_project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR

--- a/common/spark-conf/spark-defaults.conf
+++ b/common/spark-conf/spark-defaults.conf
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+# Example:
+# spark.master                     spark://master:7077
+# spark.eventLog.enabled           true
+# spark.eventLog.dir               hdfs://namenode:8021/directory
+# spark.serializer                 org.apache.spark.serializer.KryoSerializer
+# spark.driver.memory              5g
+# spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
+spark.ui.reverseProxy		   true
+spark.ui.reverseProxyUrl           /

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -14,6 +14,15 @@ function app_exit {
     fi
 }
 
+function check_reverse_proxy {
+    grep -e "^spark\.ui\.reverseProxy" $SPARK_HOME/conf/spark-defaults.conf &> /dev/null
+    if [ "$?" -ne 0 ]; then
+        echo "Appending default reverse proxy config to spark-defaults.conf"
+        echo "spark.ui.reverseProxy              true" >> $SPARK_HOME/conf/spark-defaults.conf
+        echo "spark.ui.reverseProxyUrl           /" >> $SPARK_HOME/conf/spark-defaults.conf
+    fi
+}
+
 # For JAR based applications (APP_MAIN_CLASS set), look for a single JAR file if APP_FILE
 # is not set and use that. If there is not exactly 1 jar APP_FILE will remain unset.
 # For Python applications, look for a single .py file
@@ -68,6 +77,10 @@ if [ -n "$OSHINKO_SPARK_DRIVER_CONFIG" ]; then
     fi
     rm $tmpfile
 fi
+
+# As a final check on spark config, add the reverse proxy settings if
+# the configuration does not already contain values for them
+check_reverse_proxy
 
 # See if the cluster already exists
 line=$($CLI get $OSHINKO_CLUSTER_NAME $CLI_ARGS 2>&1)


### PR DESCRIPTION
This change adds the same default spark configs to driver images
generated through s2i as are included in openshift-spark. These
configs can still be overridden via a configmap or spark-conf
directory co-located with source code.