### PR TITLE
Change the tag that s2i uses to build the oshinko-cli

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -22,7 +22,7 @@ clean:
 
 oshinko-cli:
 	- mkdir -p $(clonepath)
-	- cd $(clonepath) && git clone -b v1.0.0 https://github.com/radanalyticsio/oshinko-cli
+	- cd $(clonepath) && git clone -b v0.2.0 https://github.com/radanalyticsio/oshinko-cli
 	cd $(makepath) && make extended
 
 process-driver-config:

--- a/common/Makefile
+++ b/common/Makefile
@@ -22,7 +22,7 @@ clean:
 
 oshinko-cli:
 	- mkdir -p $(clonepath)
-	- cd $(clonepath) && git clone -b v0.1.0 https://github.com/radanalyticsio/oshinko-cli
+	- cd $(clonepath) && git clone -b v1.0.0 https://github.com/radanalyticsio/oshinko-cli
 	cd $(makepath) && make extended
 
 process-driver-config:


### PR DESCRIPTION
Should use tag v0.2.0 now