### PR TITLE
Remove -f flag on docker tag in scala Makefile

### DIFF
--- a/scala/Makefile
+++ b/scala/Makefile
@@ -18,7 +18,7 @@ clean:
 	rm -rf utils
 
 push: build
-	sudo docker tag -f $(LOCAL_IMAGE) $(PUSH_IMAGE)
+	sudo docker tag $(LOCAL_IMAGE) $(PUSH_IMAGE)
 	sudo docker push $(PUSH_IMAGE)
 
 utils:


### PR DESCRIPTION
The -f flag has been deprecated in newer docker versions.