### PR TITLE
Ignore error on make clean in pyspark Makefile

### DIFF
--- a/pyspark/Makefile
+++ b/pyspark/Makefile
@@ -14,7 +14,7 @@ build:
 	sudo docker build --pull -t $(LOCAL_IMAGE) -f $(DOCKERFILE) $(DOCKERFILE_CONTEXT)
 
 clean:
-	sudo docker rmi $(LOCAL_IMAGE)
+	- sudo docker rmi $(LOCAL_IMAGE)
 	rm -rf utils
 
 push: build


### PR DESCRIPTION
Don't cause an error if rmi of local image fails