### PR TITLE
Remove extraneous tabs from config file

### DIFF
--- a/common/spark-conf/spark-defaults.conf
+++ b/common/spark-conf/spark-defaults.conf
@@ -25,5 +25,5 @@
 # spark.serializer                 org.apache.spark.serializer.KryoSerializer
 # spark.driver.memory              5g
 # spark.executor.extraJavaOptions  -XX:+PrintGCDetails -Dkey=value -Dnumbers="one two three"
-spark.ui.reverseProxy		   true
+spark.ui.reverseProxy              true
 spark.ui.reverseProxyUrl           /


### PR DESCRIPTION
Tabs will mess up formatting for some things,
notably storage of text in configmaps