### PR TITLE
Add signal handling to driver launch script to clean up ephemeral clusters

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -25,7 +25,7 @@ function check_reverse_proxy {
 
 function delete_ephemeral {
     if [ "$CREATED" == true ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
-        echo "Deleting cluster"
+        echo "Deleting cluster $OSHINKO_CLUSTER_NAME"
         line=$($CLI delete $OSHINKO_CLUSTER_NAME $CLI_ARGS 2>&1)
         if [ "$?" -ne 0 ]; then
            echo "Error, cluster deletion returned error, output from oshinko-cli:"
@@ -195,7 +195,7 @@ else
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
     PID=$!
     wait $PID
-    PID=
+    unset PID
     delete_ephemeral
 fi
 app_exit

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -23,6 +23,25 @@ function check_reverse_proxy {
     fi
 }
 
+function delete_ephemeral {
+    if [ "$CREATED" == true ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
+        echo "Deleting cluster"
+        line=$($CLI delete $OSHINKO_CLUSTER_NAME $CLI_ARGS 2>&1)
+        if [ "$?" -ne 0 ]; then
+           echo "Error, cluster deletion returned error, output from oshinko-cli:"
+           echo "$line"
+        fi
+	CREATED=false
+    fi
+}
+
+function handle_term {
+    delete_ephemeral
+    exit 0
+}
+
+trap handle_term SIGTERM SIGINT
+
 # For JAR based applications (APP_MAIN_CLASS set), look for a single JAR file if APP_FILE
 # is not set and use that. If there is not exactly 1 jar APP_FILE will remain unset.
 # For Python applications, look for a single .py file
@@ -165,14 +184,6 @@ else
     fi
     echo spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
     spark-submit $CLASS_OPTION --master $master $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-
-    if [ "$CREATED" == true ] && [ ${OSHINKO_DEL_CLUSTER:-true} == true ]; then
-        echo "Deleting cluster"
-        line=$($CLI delete $OSHINKO_CLUSTER_NAME $CLI_ARGS 2>&1)
-        if [ "$?" -ne 0 ]; then
-           echo "Error, cluster deletion returned error, output from oshinko-cli:"
-           echo "$line"
-        fi
-    fi
+    delete_ephemeral
 fi
 app_exit

--- a/java/s2i/bin/run
+++ b/java/s2i/bin/run
@@ -17,4 +17,4 @@ if [ -d $APP_ROOT/src/spark-conf ]; then
     fi
 fi
 
-$APP_ROOT/src/start.sh
+exec $APP_ROOT/src/start.sh

--- a/pyspark/s2i/bin/run
+++ b/pyspark/s2i/bin/run
@@ -17,4 +17,4 @@ if [ -d $APP_ROOT/src/spark-conf ]; then
     fi
 fi
 
-$APP_ROOT/src/start.sh
+exec $APP_ROOT/src/start.sh

--- a/scala/s2i/bin/run
+++ b/scala/s2i/bin/run
@@ -5,5 +5,4 @@
 # For more information see the documentation:
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
-
-$APP_ROOT/src/start.sh
+exec $APP_ROOT/src/start.sh


### PR DESCRIPTION
If a spark driver pod is terminated before start.sh runs to completion, an ephemeral cluster created by that driver pod will not be cleaned up.  Add a signal handler so that start.sh can handle the TERM signal from kubernetes, and run spark-submit as a background process.

This will allow the driver pod to delete any ephemeral cluster that it created regardless of when it receives a TERM signal.