### PR TITLE
SCL changes for pyspark

### DIFF
--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -46,7 +46,6 @@ RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
     cp -rp utils/* $APP_ROOT/src && \
     rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i
 
-RUN source /opt/app-root/etc/scl_enable && source /opt/app-root/bin/activate && \
-    pip install numpy
+RUN source /opt/app-root/etc/scl_enable && pip install numpy
 
 CMD $STI_SCRIPTS_PATH/usage

--- a/Dockerfile.pyspark
+++ b/Dockerfile.pyspark
@@ -46,6 +46,7 @@ RUN cd /go/src/github.com/radanalyticsio/oshinko-s2i/pyspark && \
     cp -rp utils/* $APP_ROOT/src && \
     rm -rf /go/src/github.com/radanalyticsio/oshinko-s2i
 
-RUN source /opt/app-root/bin/activate && pip install numpy
+RUN source /opt/app-root/etc/scl_enable && source /opt/app-root/bin/activate && \
+    pip install numpy
 
 CMD $STI_SCRIPTS_PATH/usage


### PR DESCRIPTION
The base CentOS image for S2I now uses python2.7 from SCL. Thus, you must explicitly enable SCL when running pip in a layer for installing packages like numpy.