### PR TITLE
Add downard api items to the s2i templates

### DIFF
--- a/java/javabuilddc.json
+++ b/java/javabuilddc.json
@@ -222,11 +222,43 @@
                            {
                               "name": "OSHINKO_SPARK_DRIVER_CONFIG",
                               "value": "${OSHINKO_SPARK_DRIVER_CONFIG}"
+                           },
+                           {
+                              "name": "POD_NAME",
+                              "valueFrom":
+                                {
+                                   "fieldRef":
+                                      {
+                                         "fieldPath": "metadata.name"
+                                      }
+                                }
                            }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always"
+                        "imagePullPolicy": "Always",
+                        "volumeMounts": [
+                           {
+                              "mountPath": "/etc/podinfo",
+                              "name": "podinfo",
+                              "readOnly": false
+                           }
+                        ]
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "downwardAPI": {
+                           "items": [
+                              {
+                                 "fieldRef": {
+                                    "fieldPath": "metadata.labels"
+                                 },
+                                 "path": "labels"
+                              }
+                           ]
+                        },
+                        "name": "podinfo"
                      }
                   ],
                   "restartPolicy": "Always",

--- a/pyspark/pysparkbuilddc.json
+++ b/pyspark/pysparkbuilddc.json
@@ -244,12 +244,6 @@
                                     "fieldPath": "metadata.labels"
                                  },
                                  "path": "labels"
-                              },
-                              {
-                                 "fieldRef": {
-                                    "fieldPath": "metadata.annotations"
-                                 },
-                                 "path": "annotations"
                               }
                            ]
                         },

--- a/pyspark/pysparkdc.json
+++ b/pyspark/pysparkdc.json
@@ -158,12 +158,6 @@
                                     "fieldPath": "metadata.labels"
                                  },
                                  "path": "labels"
-                              },
-                              {
-                                 "fieldRef": {
-                                    "fieldPath": "metadata.annotations"
-                                 },
-                                 "path": "annotations"
                               }
                            ]
                         },

--- a/scala/scalabuilddc.json
+++ b/scala/scalabuilddc.json
@@ -222,11 +222,43 @@
                            {
                               "name": "OSHINKO_SPARK_DRIVER_CONFIG",
                               "value": "${OSHINKO_SPARK_DRIVER_CONFIG}"
+                           },
+                           {
+                              "name": "POD_NAME",
+                              "valueFrom":
+                                {
+                                   "fieldRef":
+                                      {
+                                         "fieldPath": "metadata.name"
+                                      }
+                                }
                            }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always"
+                        "imagePullPolicy": "Always",
+                        "volumeMounts": [
+                           {
+                              "mountPath": "/etc/podinfo",
+                              "name": "podinfo",
+                              "readOnly": false
+                           }
+                        ]
+                     }
+                  ],
+                  "volumes": [
+                     {
+                        "downwardAPI": {
+                           "items": [
+                              {
+                                 "fieldRef": {
+                                    "fieldPath": "metadata.labels"
+                                 },
+                                 "path": "labels"
+                              }
+                           ]
+                        },
+                        "name": "podinfo"
                      }
                   ],
                   "restartPolicy": "Always",


### PR DESCRIPTION
The s2i templates which create driver dcs need to add items
from the downward api.