### PR TITLE
Make template tests use local builds instead of public images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ language: go
 services:
 - docker
 matrix:
+  # no need to include the build target at present because the template
+  # tests perform builds from the local source to do the tests
   include:
-    - env: TO_TEST=build
     - env: TO_TEST=ephemeral
     - env: TO_TEST=pyspark-templates
     - env: TO_TEST=java-templates

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,25 @@ before_install:
       echo $PATH
       # below cmd is important to get oc working in ubuntu
       sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v1.5.1 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
-      sudo oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+
+      # Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
+      # See if a retry within the same test works
+      set +e
+      built=false
+      for tries in {1..3}; do
+          sudo oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+          if [ "$?" -eq 0 ]; then
+              built=true
+              break
+          fi
+          echo "Retrying oc cluster up after failure"
+          sudo oc cluster down
+      done
+      set -e
+      if [ "$built" == false ]; then
+          exit 1
+      fi
+
       sudo chmod -R a+rwX /home/travis/.kube
       sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
       # find IP:PORT of openshift

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 alldirs =  pyspark java scala
 pushdirs = pyspark java scala
 
-# Set the S2I_TEST_IMAGE env var so that the
-# build of the pyspark s2i image and the
-# tests use the same image name when running
-# the test-cmd target
-S2I_TEST_IMAGE ?= pyspark-s2i-testimage
-export S2I_TEST_IMAGE
+# Set the S2I_TEST_IMAGE_XXX env vars so that the
+# build of the local images and the tests use the
+# same image name when running the test targets
+S2I_TEST_IMAGE_PREFIX ?= s2i-testimage
+S2I_TEST_IMAGE_PYSPARK ?= $(S2I_TEST_IMAGE_PREFIX)-pyspark
+S2I_TEST_IMAGE_JAVA ?= $(S2I_TEST_IMAGE_PREFIX)-java
+S2I_TEST_IMAGE_SCALA ?= $(S2I_TEST_IMAGE_PREFIX)-scala
+export S2I_TEST_IMAGE_PREFIX
+export S2I_TEST_IMAGE_PYSPARK
+export S2I_TEST_IMAGE_JAVA
+export S2I_TEST_IMAGE_SCALA
 
 build: CMD=build
 push: CMD=push
@@ -25,25 +30,31 @@ $(alldirs):
 # Otherwise the test will assume an OpenShift instance created
 # with 'oc cluster up'
 test-ephemeral:
-	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE) make build
+	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
 	test/e2e/run.sh "(ephemeral|incomplete)"
 
 test-java-templates:
+	cd java; LOCAL_IMAGE=$(S2I_TEST_IMAGE_JAVA) make build
 	test/e2e/run.sh templates/java
 
 test-pyspark-templates:
-	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE) make build
+	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
 	test/e2e/run.sh templates/pyspark
 
 test-scala-templates:
+	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
 	test/e2e/run.sh templates/scala
 
 test-templates:
-	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE) make build
+	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
+	cd java; LOCAL_IMAGE=$(S2I_TEST_IMAGE_JAVA) make build
+	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
 	test/e2e/run.sh templates
 
 test-e2e:
-	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE) make build
+	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
+	cd java; LOCAL_IMAGE=$(S2I_TEST_IMAGE_JAVA) make build
+	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
 	test/e2e/run.sh
 
 .PHONY: build clean push $(alldirs) test-e2e test-ephemeral test-java-templates test-pyspark-templates test-scala-templates test-templates

--- a/java/Makefile
+++ b/java/Makefile
@@ -1,4 +1,4 @@
-LOCAL_IMAGE=radanalytics-java-spark
+LOCAL_IMAGE ?= radanalytics-java-spark
 
 # If you are going to push the built image to a registry
 # using the "push" make target then you should replace

--- a/scala/Makefile
+++ b/scala/Makefile
@@ -1,4 +1,4 @@
-LOCAL_IMAGE=radanalytics-scala-spark
+LOCAL_IMAGE ?= radanalytics-scala-spark
 
 # If you are going to push the built image to a registry
 # using the "push" make target then you should replace

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -13,7 +13,7 @@ if [ -z "$S2I_TEST_IMAGE_JAVA" ]; then
     if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
 	S2I_TEST_IMAGE_JAVA=$S2I_TEST_IMAGE_PREFIX-java
     else
-	S2I_TEST_IMAGE_PYSPARK=radanalytics-java-spark
+	S2I_TEST_IMAGE_JAVA=radanalytics-java-spark
     fi
 fi
 
@@ -21,7 +21,7 @@ if [ -z "$S2I_TEST_IMAGE_SCALA" ]; then
     if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
 	S2I_TEST_IMAGE_SCALA=$S2I_TEST_IMAGE_PREFIX-scala
     else
-	S2I_TEST_IMAGE_PYSPARK=radanalytics-scala-spark
+	S2I_TEST_IMAGE_SCALA=radanalytics-scala-spark
     fi
 fi
 

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -1,7 +1,30 @@
 #!/bin/bash
 S2I_TEST_INTEGRATED_REGISTRY=${S2I_TEST_INTEGRATED_REGISTRY:-}
 
-S2I_TEST_IMAGE=${S2I_TEST_IMAGE:-radanalytics-pyspark}
+if [ -z "$S2I_TEST_IMAGE_PYSPARK" ]; then
+    if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
+	S2I_TEST_IMAGE_PYSPARK=$S2I_TEST_IMAGE_PREFIX-pyspark
+    else
+	S2I_TEST_IMAGE_PYSPARK=radanalytics-pyspark
+    fi
+fi
+
+if [ -z "$S2I_TEST_IMAGE_JAVA" ]; then
+    if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
+	S2I_TEST_IMAGE_JAVA=$S2I_TEST_IMAGE_PREFIX-java
+    else
+	S2I_TEST_IMAGE_PYSPARK=radanalytics-java-spark
+    fi
+fi
+
+if [ -z "$S2I_TEST_IMAGE_SCALA" ]; then
+    if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
+	S2I_TEST_IMAGE_SCALA=$S2I_TEST_IMAGE_PREFIX-scala
+    else
+	S2I_TEST_IMAGE_PYSPARK=radanalytics-scala-spark
+    fi
+fi
+
 
 S2I_TEST_SPARK_IMAGE=${S2I_TEST_SPARK_IMAGE:-docker.io/radanalyticsio/openshift-spark}
 
@@ -23,7 +46,9 @@ function print_test_env {
     else
         echo Not using integrated registry
     fi
-    echo Using local s2i image $S2I_TEST_IMAGE
+    echo Using local s2i pyspark image $S2I_TEST_IMAGE_PYSPARK
+    echo Using local s2i java image $S2I_TEST_IMAGE_JAVA
+    echo Using local s2i scala image $S2I_TEST_IMAGE_SCALA
     echo Using spark image $S2I_TEST_SPARK_IMAGE
     echo Using $S2I_TEST_WORKERS workers
 }
@@ -200,18 +225,23 @@ function make_image() {
         # In the case of a "normal" openshift cluster, the image we'll use for build has to be
         # available as an imagestream.
         set +e
-        tmp=$(docker history $S2I_TEST_IMAGE)
+        tmp=$(docker history $S2I_TEST_IMAGE_PYSPARK)
         res=$?
         set -e
         if [ "$res" -ne 0 ]; then
-            echo Uh oh, image $S2I_TEST_IMAGE does not exist
+            echo Uh oh, image $S2I_TEST_IMAGE_PYSPARK does not exist
             return 1
         fi
         if [ -z "${S2I_TEST_INTEGRATED_REGISTRY}" ]; then
-            os::cmd::expect_success 'oc new-build --name=play "$S2I_TEST_IMAGE" --binary'
+            os::cmd::expect_success 'oc new-build --name=play "$S2I_TEST_IMAGE_PYSPARK" --binary'
         else
-            docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
-            docker tag ${S2I_TEST_IMAGE} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
+	    docker login --help | grep email
+	    if [ "$?" -eq 0 ]; then
+                docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+	    else
+                docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+	    fi
+            docker tag ${S2I_TEST_IMAGE_PYSPARK} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
             docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
             os::cmd::expect_success 'oc new-build --name=play --image-stream=radanalytics-pyspark --binary'
         fi

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -216,7 +216,7 @@ function make_image() {
     TEST_IMAGE=play
     set +e
     oc get buildconfig play &> /dev/null
-    res=$?
+    local res=$?
     set -e
     if [ "$res" -ne 0 ]; then
         # The ip address of the internal registry may be set to support running against
@@ -235,12 +235,15 @@ function make_image() {
         if [ -z "${S2I_TEST_INTEGRATED_REGISTRY}" ]; then
             os::cmd::expect_success 'oc new-build --name=play "$S2I_TEST_IMAGE_PYSPARK" --binary'
         else
-	    docker login --help | grep email
-	    if [ "$?" -eq 0 ]; then
+            set +e
+            docker login --help | grep email &> /dev/null
+            res=$?
+            set -e
+            if [ "$res" -eq 0 ]; then
                 docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
-	    else
+            else
                 docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
-	    fi
+            fi
             docker tag ${S2I_TEST_IMAGE_PYSPARK} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
             docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
             os::cmd::expect_success 'oc new-build --name=play --image-stream=radanalytics-pyspark --binary'

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -97,7 +97,16 @@ function set_app_main_class() {
 function run_app() {
     app_preamble
     set +e
+    # If is a build is necessary, it can take a long time and this can cause tests in
+    # environments like travis to time out from lack of output.  So if the imagestream
+    # associated with APP_NAME doesn't already exist, watch the build log to produce log
+    # output and prevent timeout.
+    oc get is $APP_NAME &> /dev/null
+    local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME -p APP_ARGS="$APPARGS" -p OSHINKO_DEL_CLUSTER=$DEL_CLUSTER -p OSHINKO_NAMED_CONFIG=$NAMED_CONFIG -p OSHINKO_SPARK_DRIVER_CONFIG=$DRIVER_CONFIG -p OSHINKO_CLUSTER_NAME=$GEN_CLUSTER_NAME -p SPARK_OPTIONS="$SPARK_OPTIONS" $APP_FILE $EXIT_FLAG $APP_MAIN_CLASS &> /dev/null
+    if [ "$stream_exists" -ne 0 ]; then
+       oc log buildconfig/$APP_NAME -f
+    fi
     set -e
     # Allow some tests to skip the wait for the running app, because they don't care
     if [ "$#" -eq 0 ]; then
@@ -105,11 +114,15 @@ function run_app() {
     fi
 }
 
-
 function run_app_without_optionals() {
     app_preamble
     set +e
+    oc get is $APP_NAME &> /dev/null
+    local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME -p OSHINKO_CLUSTER_NAME=$GEN_CLUSTER_NAME $APP_MAIN_CLASS &> /dev/null
+    if [ "$stream_exists" -ne 0 ]; then
+       oc log buildconfig/$APP_NAME -f
+    fi
     set -e
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'cluster'  $((10*minute))
 }
@@ -117,7 +130,12 @@ function run_app_without_optionals() {
 function run_app_without_clustername() {
     app_preamble
     set +e
+    oc get is $APP_NAME &> /dev/null
+    local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME $APP_MAIN_CLASS &> /dev/null
+    if [ "$stream_exists" -ne 0 ]; then
+       oc log buildconfig/$APP_NAME -f
+    fi
     set -e
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'cluster'  $((10*minute))
 }
@@ -129,13 +147,17 @@ function run_app_without_application_name() {
 
 function test_no_app_name {
     set_defaults
-    os::cmd::expect_success 'oc delete dc -l app'
-    os::cmd::try_until_text 'oc get pod -l app' 'No resources found'
+    os::cmd::expect_success 'oc delete buildconfig -l app'
+    os::cmd::try_until_text 'oc get buildconfig -l app' 'No resources found'
     run_app_without_application_name
-    os::cmd::try_until_not_text 'oc get pod -l app' 'No resources found' $((10*minute))
-    DRIVER=$(oc get pod -l app --template='{{index .items 0 "metadata" "name"}}')
-    os::cmd::try_until_text 'oc logs "$DRIVER"' 'cluster'
-    os::cmd::expect_success 'oc delete dc -l app'
+    os::cmd::try_until_not_text 'oc get buildconfig -l app' 'No resources found' $((10*minute))
+    NAME=$(oc get buildconfig -l app --template='{{index .items 0 "metadata" "name"}}')
+    os::cmd::try_until_success 'oc logs "$NAME"-1-build | grep "$GIT_URI"'
+    os::cmd::try_until_success 'oc get dc/"$NAME"'
+    os::cmd::try_until_success 'oc get is/"$NAME"'
+    os::cmd::expect_success 'oc delete buildconfig "$NAME"'
+    os::cmd::expect_success 'oc delete is "$NAME"'
+    os::cmd::expect_success 'oc delete dc "$NAME"'
 }
 
 function test_app_args {

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -99,9 +99,9 @@ function poll_build() {
     local BUILDNUM=$(oc get buildconfig $APP_NAME --template='{{index .status "lastVersion"}}')
     while true; do
         status=$(oc get build "$APP_NAME"-$BUILDNUM --template="{{index .status \"phase\"}}")
-	if [ "$status" != "Complete" -a "$status" != "Failed" ]; then
+	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
 	    echo Build for $APP_NAME status is $status, waiting ...
-	elif [ "$status" == "Failed" ]; then
+	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
 	    oc log buildconfig/$APP_NAME
 	    oc delete buildconfig $APP_NAME
 	    oc delete is $APP_NAME

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -307,3 +307,29 @@ function test_fixed_exit {
     os::cmd::try_until_success 'oc exec "$DRIVER" -- env | grep "APP_EXIT=true"'  $((10*minute))
     cleanup_app
 }
+
+function fix_template() {
+    local file=$1
+    local original_image=$2
+    local new_image=$3
+    # If the integrated registry is defined, then we have to do a push of the local image
+    # into the project and modify the template to use an ImageStreamTag
+    if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+	docker login --help | grep email
+	if [ "$?" -eq 0 ]; then
+            docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+	else
+            docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+	fi
+        docker tag ${new_image} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
+        docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
+	sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
+        sed -i "s^\"name\": \"$original_image\"^\"name\": \"$new_image:latest\"^" $file
+
+    # if the integrated registry is not defined then we just use DockerImage with the local image
+    # and remove the forcePull (forcePull will break the ability of "oc cluster up" to grab the local image)
+    else
+        sed -i "s^\"name\": \"$original_image\"^\"name\": \"$new_image\"^" $file
+        sed -i "s^\"forcePull\".*^^" $file
+    fi
+}

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -94,6 +94,28 @@ function set_app_main_class() {
     fi
 }
 
+function poll_build() {
+    local status
+    local BUILDNUM=$(oc get buildconfig $APP_NAME --template='{{index .status "lastVersion"}}')
+    while true; do
+        status=$(oc get build "$APP_NAME"-$BUILDNUM --template="{{index .status \"phase\"}}")
+	if [ "$status" != "Complete" -a "$status" != "Failed" ]; then
+	    echo Build for $APP_NAME status is $status, waiting ...
+	elif [ "$status" == "Failed" ]; then
+	    oc log buildconfig/$APP_NAME
+	    oc delete buildconfig $APP_NAME
+	    oc delete is $APP_NAME
+	    set +e
+	    oc delete dc $APP_NAME
+	    set -e
+	    return 1
+	else
+	    break
+	fi
+	sleep 30
+    done
+}
+
 function run_app() {
     app_preamble
     set +e
@@ -104,12 +126,12 @@ function run_app() {
     oc get is $APP_NAME &> /dev/null
     local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME -p APP_ARGS="$APPARGS" -p OSHINKO_DEL_CLUSTER=$DEL_CLUSTER -p OSHINKO_NAMED_CONFIG=$NAMED_CONFIG -p OSHINKO_SPARK_DRIVER_CONFIG=$DRIVER_CONFIG -p OSHINKO_CLUSTER_NAME=$GEN_CLUSTER_NAME -p SPARK_OPTIONS="$SPARK_OPTIONS" $APP_FILE $EXIT_FLAG $APP_MAIN_CLASS &> /dev/null
-    if [ "$stream_exists" -ne 0 ]; then
-       oc log buildconfig/$APP_NAME -f
-    fi
     set -e
     # Allow some tests to skip the wait for the running app, because they don't care
     if [ "$#" -eq 0 ]; then
+	if [ "$stream_exists" -ne 0 ]; then
+            poll_build
+	fi
         os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'cluster' $((10*minute))
     fi
 }
@@ -120,10 +142,10 @@ function run_app_without_optionals() {
     oc get is $APP_NAME &> /dev/null
     local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME -p OSHINKO_CLUSTER_NAME=$GEN_CLUSTER_NAME $APP_MAIN_CLASS &> /dev/null
-    if [ "$stream_exists" -ne 0 ]; then
-       oc log buildconfig/$APP_NAME -f
-    fi
     set -e
+    if [ "$stream_exists" -ne 0 ]; then
+       poll_build
+    fi
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'cluster'  $((10*minute))
 }
 
@@ -133,10 +155,10 @@ function run_app_without_clustername() {
     oc get is $APP_NAME &> /dev/null
     local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME $APP_MAIN_CLASS &> /dev/null
-    if [ "$stream_exists" -ne 0 ]; then
-       oc log buildconfig/$APP_NAME -f
-    fi
     set -e
+    if [ "$stream_exists" -ne 0 ]; then
+       poll_build
+    fi
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'cluster'  $((10*minute))
 }
 

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -174,7 +174,7 @@ function test_no_app_name {
     run_app_without_application_name
     os::cmd::try_until_not_text 'oc get buildconfig -l app' 'No resources found' $((10*minute))
     NAME=$(oc get buildconfig -l app --template='{{index .items 0 "metadata" "name"}}')
-    os::cmd::try_until_success 'oc logs "$NAME"-1-build | grep "$GIT_URI"'
+    os::cmd::try_until_success 'oc logs "$NAME"-1-build | grep "$GIT_URI"'  $((5*minute)) 
     os::cmd::try_until_success 'oc get dc/"$NAME"'
     os::cmd::try_until_success 'oc get is/"$NAME"'
     os::cmd::expect_success 'oc delete buildconfig "$NAME"'
@@ -359,15 +359,18 @@ function fix_template() {
     # If the integrated registry is defined, then we have to do a push of the local image
     # into the project and modify the template to use an ImageStreamTag
     if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
-	docker login --help | grep email
-	if [ "$?" -eq 0 ]; then
+        set +e
+        docker login --help | grep email &> /dev/null
+        local res=$?
+        set -e
+        if [ "$res" -eq 0 ]; then
             docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
-	else
+        else
             docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
-	fi
+        fi
         docker tag ${new_image} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
         docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
-	sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
+        sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
         sed -i "s^\"name\": \"$original_image\"^\"name\": \"$new_image:latest\"^" $file
 
     # if the integrated registry is not defined then we just use DockerImage with the local image
@@ -376,4 +379,23 @@ function fix_template() {
         sed -i "s^\"name\": \"$original_image\"^\"name\": \"$new_image\"^" $file
         sed -i "s^\"forcePull\".*^^" $file
     fi
+}
+
+function check_image {
+    set_defaults
+    run_app skip_wait
+    os::cmd::try_until_success 'oc get buildconfig "$APP_NAME"' $((10*minute))
+    IMAGE=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "name"}}')
+    KIND=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "kind"}}')
+    os::cmd::expect_success 'echo "$IMAGE" | grep "$S2I_TEST_IMAGE_PYSPARK"'
+    if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+        os::cmd::expect_success 'echo "$KIND" | grep "ImageStreamTag"'
+    else
+        os::cmd::expect_success 'echo "$KIND" | grep "DockerImage"'
+    fi
+    oc delete buildconfig $APP_NAME &> /dev/null
+    oc delete is $APP_NAME &> /dev/null
+    set +e
+    oc delete dc $APP_NAME &> /dev/null
+    set -e
 }

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -382,12 +382,13 @@ function fix_template() {
 }
 
 function check_image {
+    local testimage=$1
     set_defaults
     run_app skip_wait
     os::cmd::try_until_success 'oc get buildconfig "$APP_NAME"' $((10*minute))
     IMAGE=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "name"}}')
     KIND=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "kind"}}')
-    os::cmd::expect_success 'echo "$IMAGE" | grep "$S2I_TEST_IMAGE_PYSPARK"'
+    os::cmd::expect_success 'echo "$IMAGE" | grep "$testimage"'
     if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
         os::cmd::expect_success 'echo "$KIND" | grep "ImageStreamTag"'
     else

--- a/test/e2e/templates/buildonly
+++ b/test/e2e/templates/buildonly
@@ -9,8 +9,11 @@ function run_app() {
     oc get is $APP_NAME &> /dev/null
     local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME="$APP_NAME" $APP_FILE &> /dev/null
-    if [ "$stream_exists" -ne 0 ]; then
-       oc log buildconfig/$APP_NAME -f
+    # Allow some tests to skip the wait for the running app, because they don't care
+    if [ "$#" -eq 0 ]; then
+        if [ "$stream_exists" -ne 0 ]; then
+            poll_build
+        fi
     fi
     set -e
 }

--- a/test/e2e/templates/buildonly
+++ b/test/e2e/templates/buildonly
@@ -6,7 +6,12 @@
 function run_app() {
     app_preamble
     set +e
+    oc get is $APP_NAME &> /dev/null
+    local stream_exists=$?
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME="$APP_NAME" $APP_FILE &> /dev/null
+    if [ "$stream_exists" -ne 0 ]; then
+       oc log buildconfig/$APP_NAME -f
+    fi
     set -e
 }
 
@@ -18,7 +23,8 @@ function build_test_no_app_name {
     os::cmd::try_until_not_text 'oc get buildconfig -l app' 'No resources found' $((10*minute))
     NAME=$(oc get buildconfig -l app --template='{{index .items 0 "metadata" "name"}}')
     os::cmd::try_until_success 'oc logs "$NAME"-1-build | grep "$GIT_URI"'
-    os::cmd::expect_success 'oc delete buildconfig -l app'
+    os::cmd::try_until_success 'oc get is/"$NAME"'
+    os::cmd::expect_success 'oc delete buildconfig "$NAME"'
     os::cmd::expect_success 'oc delete is "$NAME"'
 }
 

--- a/test/e2e/templates/java/build/javabuild.sh
+++ b/test/e2e/templates/java/build/javabuild.sh
@@ -10,8 +10,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 source $SCRIPT_DIR/../../buildonly
 
+RESOURCE_DIR=$TEST_DIR/resources
+cp $JAVATEMP_DIR/javabuild.json $RESOURCE_DIR/javabuild.json
+fix_template $RESOURCE_DIR/javabuild.json radanalyticsio/radanalytics-java-spark $S2I_TEST_IMAGE_JAVA
+set_template $RESOURCE_DIR/javabuild.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
-set_template $JAVATEMP_DIR/javabuild.json
 set_fixed_app_name java-build
 
 set_worker_count $S2I_TEST_WORKERS

--- a/test/e2e/templates/java/build/javabuild.sh
+++ b/test/e2e/templates/java/build/javabuild.sh
@@ -22,7 +22,7 @@ set_worker_count $S2I_TEST_WORKERS
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_JAVA
 
 echo "++ build_test_no_app_name"
 build_test_no_app_name

--- a/test/e2e/templates/java/build/javabuild.sh
+++ b/test/e2e/templates/java/build/javabuild.sh
@@ -21,6 +21,9 @@ set_worker_count $S2I_TEST_WORKERS
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ build_test_no_app_name"
 build_test_no_app_name
 

--- a/test/e2e/templates/java/builddc/javabuilddc.sh
+++ b/test/e2e/templates/java/builddc/javabuilddc.sh
@@ -21,7 +21,7 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_JAVA
 
 echo "++ test_no_app_name"
 test_no_app_name

--- a/test/e2e/templates/java/builddc/javabuilddc.sh
+++ b/test/e2e/templates/java/builddc/javabuilddc.sh
@@ -20,6 +20,9 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ test_no_app_name"
 test_no_app_name
 

--- a/test/e2e/templates/java/builddc/javabuilddc.sh
+++ b/test/e2e/templates/java/builddc/javabuilddc.sh
@@ -20,6 +20,9 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_exit
 
@@ -43,9 +46,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/java/builddc/javabuilddc.sh
+++ b/test/e2e/templates/java/builddc/javabuilddc.sh
@@ -8,7 +8,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 JAVATEMP_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i/')/java
-set_template $JAVATEMP_DIR/javabuilddc.json
+RESOURCE_DIR=$TEST_DIR/resources
+
+cp  $JAVATEMP_DIR/javabuilddc.json $RESOURCE_DIR/javabuilddc.json
+fix_template $RESOURCE_DIR/javabuilddc.json radanalyticsio/radanalytics-java-spark $S2I_TEST_IMAGE_JAVA
+set_template $RESOURCE_DIR/javabuilddc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name java-build

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -24,6 +24,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ test_no_app_name"
 test_no_app_name
 

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -24,6 +24,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_fixed_exit
 
@@ -47,9 +50,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 RESOURCE_DIR=$TEST_DIR/resources
-set_template $RESOURCE_DIR/oshinko-java-spark-build-dc.yaml
+set_template $RESOURCE_DIR/oshinko-java-spark-build-dc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name java-build
@@ -18,7 +18,8 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 # it to the resources directory
 set +e
 oc create -f https://radanalytics.io/resources.yaml &> /dev/null
-oc export template oshinko-java-spark-build-dc > $RESOURCE_DIR/oshinko-java-spark-build-dc.yaml
+oc export template oshinko-java-spark-build-dc -o json > $RESOURCE_DIR/oshinko-java-spark-build-dc.json
+fix_template $RESOURCE_DIR/oshinko-java-spark-build-dc.json radanalyticsio/radanalytics-java-spark $S2I_TEST_IMAGE_JAVA
 set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -25,7 +25,7 @@ set -e
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_JAVA
 
 echo "++ test_no_app_name"
 test_no_app_name

--- a/test/e2e/templates/pyspark/build/pysparkbuild.sh
+++ b/test/e2e/templates/pyspark/build/pysparkbuild.sh
@@ -10,8 +10,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 source $SCRIPT_DIR/../../buildonly
 
+RESOURCE_DIR=$TEST_DIR/resources
+cp $PYSPARK_DIR/pysparkbuild.json $RESOURCE_DIR/pysparkbuild.json
+fix_template $RESOURCE_DIR/pysparkbuild.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
+set_template $RESOURCE_DIR/pysparkbuild.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
-set_template $PYSPARK_DIR/pysparkbuild.json
 set_fixed_app_name pyspark-build
 
 set_worker_count $S2I_TEST_WORKERS

--- a/test/e2e/templates/pyspark/build/pysparkbuild.sh
+++ b/test/e2e/templates/pyspark/build/pysparkbuild.sh
@@ -22,7 +22,7 @@ set_worker_count $S2I_TEST_WORKERS
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_PYSPARK
 
 echo "++ build_test_no_app_name"
 build_test_no_app_name

--- a/test/e2e/templates/pyspark/build/pysparkbuild.sh
+++ b/test/e2e/templates/pyspark/build/pysparkbuild.sh
@@ -21,6 +21,9 @@ set_worker_count $S2I_TEST_WORKERS
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ build_test_no_app_name"
 build_test_no_app_name
 

--- a/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
@@ -19,6 +19,9 @@ set_fixed_app_name pyspark-build
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ test_no_app_name"
 test_no_app_name
 

--- a/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
@@ -8,7 +8,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 PYSPARK_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i/')/pyspark
-set_template $PYSPARK_DIR/pysparkbuilddc.json
+RESOURCE_DIR=$TEST_DIR/resources
+
+cp  $PYSPARK_DIR/pysparkbuilddc.json $RESOURCE_DIR/pysparkbuilddc.json
+fix_template $RESOURCE_DIR/pysparkbuilddc.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
+set_template $RESOURCE_DIR/pysparkbuilddc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name pyspark-build

--- a/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
@@ -20,7 +20,7 @@ set_fixed_app_name pyspark-build
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_PYSPARK
 
 echo "++ test_no_app_name"
 test_no_app_name

--- a/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
@@ -19,6 +19,9 @@ set_fixed_app_name pyspark-build
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_exit
 
@@ -42,9 +45,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/pyspark/dc/pysparkdc.sh
+++ b/test/e2e/templates/pyspark/dc/pysparkdc.sh
@@ -20,6 +20,9 @@ os::test::junit::declare_suite_start "$MY_SCRIPT"
 make_image
 set_image $TEST_IMAGE
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_exit
 
@@ -43,9 +46,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -24,7 +24,7 @@ set -e
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_PYSPARK
 
 echo "++ test_no_app_name"
 test_no_app_name

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -23,6 +23,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_fixed_exit
 
@@ -46,9 +49,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 RESOURCE_DIR=$TEST_DIR/resources
-set_template $RESOURCE_DIR/oshinko-pyspark-build-dc.yaml
+set_template $RESOURCE_DIR/oshinko-pyspark-build-dc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name pyspark-build
@@ -17,7 +17,8 @@ set_fixed_app_name pyspark-build
 # it to the resources directory
 set +e
 oc create -f https://radanalytics.io/resources.yaml &> /dev/null
-oc export template oshinko-pyspark-build-dc > $RESOURCE_DIR/oshinko-pyspark-build-dc.yaml
+oc export template oshinko-pyspark-build-dc -o json > $RESOURCE_DIR/oshinko-pyspark-build-dc.json
+fix_template $RESOURCE_DIR/oshinko-pyspark-build-dc.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
 set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -23,6 +23,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ test_no_app_name"
 test_no_app_name
 

--- a/test/e2e/templates/scala/build/scalabuild.sh
+++ b/test/e2e/templates/scala/build/scalabuild.sh
@@ -10,8 +10,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 source $SCRIPT_DIR/../../buildonly
 
+RESOURCE_DIR=$TEST_DIR/resources
+cp $SCALATEMP_DIR/scalabuild.json $RESOURCE_DIR/scalabuild.json
+fix_template $RESOURCE_DIR/scalabuild.json radanalyticsio/radanalytics-scala-spark $S2I_TEST_IMAGE_SCALA
+set_template $RESOURCE_DIR/scalabuild.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
-set_template $SCALATEMP_DIR/scalabuild.json
 set_fixed_app_name scala-build
 
 set_worker_count $S2I_TEST_WORKERS

--- a/test/e2e/templates/scala/build/scalabuild.sh
+++ b/test/e2e/templates/scala/build/scalabuild.sh
@@ -22,7 +22,7 @@ set_worker_count $S2I_TEST_WORKERS
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_SCALA
 
 echo "++ build_test_no_app_name"
 build_test_no_app_name

--- a/test/e2e/templates/scala/build/scalabuild.sh
+++ b/test/e2e/templates/scala/build/scalabuild.sh
@@ -21,6 +21,9 @@ set_worker_count $S2I_TEST_WORKERS
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ build_test_no_app_name"
 build_test_no_app_name
 

--- a/test/e2e/templates/scala/builddc/scalabuilddc.sh
+++ b/test/e2e/templates/scala/builddc/scalabuilddc.sh
@@ -20,6 +20,9 @@ set_app_main_class org.apache.spark.examples.SparkPi
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ test_no_app_name"
+test_no_app_name
+
 echo "++ test_exit"
 test_exit
 
@@ -43,9 +46,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-echo "++ test_no_app_name"
-test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/scala/builddc/scalabuilddc.sh
+++ b/test/e2e/templates/scala/builddc/scalabuilddc.sh
@@ -21,7 +21,7 @@ set_app_main_class org.apache.spark.examples.SparkPi
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_SCALA
 
 echo "++ test_no_app_name"
 test_no_app_name

--- a/test/e2e/templates/scala/builddc/scalabuilddc.sh
+++ b/test/e2e/templates/scala/builddc/scalabuilddc.sh
@@ -20,6 +20,9 @@ set_app_main_class org.apache.spark.examples.SparkPi
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 echo "++ test_no_app_name"
 test_no_app_name
 

--- a/test/e2e/templates/scala/builddc/scalabuilddc.sh
+++ b/test/e2e/templates/scala/builddc/scalabuilddc.sh
@@ -8,7 +8,11 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 SCALATEMP_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i/')/scala
-set_template $SCALATEMP_DIR/scalabuilddc.json
+RESOURCE_DIR=$TEST_DIR/resources
+
+cp  $SCALATEMP_DIR/scalabuilddc.json $RESOURCE_DIR/scalabuilddc.json
+fix_template $RESOURCE_DIR/scalabuilddc.json radanalyticsio/radanalytics-scala-spark $S2I_TEST_IMAGE_SCALA
+set_template $RESOURCE_DIR/scalabuilddc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name scala-build

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -24,6 +24,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+#echo "++ test_no_app_name"
+#test_no_app_name
+
 echo "++ test_exit"
 test_fixed_exit
 
@@ -47,9 +50,6 @@ test_driver_config
 
 echo "++ test_spark_options"
 test_spark_options
-
-#echo "++ test_no_app_name"
-#test_no_app_name
 
 echo "++ test_no_source_or_image"
 test_no_source_or_image

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -24,6 +24,9 @@ set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+echo "++ check_image"
+check_image
+
 #echo "++ test_no_app_name"
 #test_no_app_name
 

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -25,7 +25,7 @@ set -e
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 echo "++ check_image"
-check_image
+check_image $S2I_TEST_IMAGE_SCALA
 
 #echo "++ test_no_app_name"
 #test_no_app_name

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 RESOURCE_DIR=$TEST_DIR/resources
-set_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.yaml
+set_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name scala-build
@@ -18,7 +18,8 @@ set_app_main_class org.apache.spark.examples.SparkPi
 # it to the resources directory
 set +e
 oc create -f https://radanalytics.io/resources.yaml &> /dev/null
-oc export template oshinko-scala-spark-build-dc > $RESOURCE_DIR/oshinko-scala-spark-build-dc.yaml
+oc export template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
+fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark $S2I_TEST_IMAGE_SCALA
 set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"


### PR DESCRIPTION
To be a consistent whole, the tests, templates, and images should
all be based on current code in the repository. This change:

* makes a local build of java, scala, and python s2i images for
  their respective template tests
* copies the templates to the resources directory and modifies
  them with "sed" to reference the local images
* pushes the local image in question to the test project when
  the S2I_TEST_INTEGRATED_REGISTRY env var is set
* disables the separate travis build test for each of the images
  since they are now built as part of the template tests