### PR TITLE
Allow resources.yaml to be overriden locally for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,25 @@ test-java-templates:
 	cd java; LOCAL_IMAGE=$(S2I_TEST_IMAGE_JAVA) make build
 	test/e2e/run.sh templates/java
 
+test-java-radio:
+	cd java; LOCAL_IMAGE=$(S2I_TEST_IMAGE_JAVA) make build
+	test/e2e/run.sh templates/java/radio
+
 test-pyspark-templates:
 	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
 	test/e2e/run.sh templates/pyspark
 
+test-pyspark-radio:
+	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
+	test/e2e/run.sh templates/pyspark/radio
+
 test-scala-templates:
 	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
 	test/e2e/run.sh templates/scala
+
+test-scala-radio:
+	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
+	test/e2e/run.sh templates/scala/radio
 
 test-templates:
 	cd pyspark; LOCAL_IMAGE=$(S2I_TEST_IMAGE_PYSPARK) make build
@@ -57,4 +69,4 @@ test-e2e:
 	cd scala; LOCAL_IMAGE=$(S2I_TEST_IMAGE_SCALA) make build
 	test/e2e/run.sh
 
-.PHONY: build clean push $(alldirs) test-e2e test-ephemeral test-java-templates test-pyspark-templates test-scala-templates test-templates
+.PHONY: build clean push $(alldirs) test-e2e test-ephemeral test-java-templates test-pyspark-templates test-scala-templates test-templates test-pyspark-radio test-scala-radio test-java-radio

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -384,6 +384,7 @@ function fix_template() {
 function check_image {
     local testimage=$1
     set_defaults
+    force_random_app_name
     run_app skip_wait
     os::cmd::try_until_success 'oc get buildconfig "$APP_NAME"' $((10*minute))
     IMAGE=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "name"}}')

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -18,7 +18,7 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 # it to the resources directory
 set +e
 if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
-    echo Using local resource.yaml
+    echo Using local resources.yaml
     oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
 else
     echo Using https://radanalytics.io/resources.yaml

--- a/test/e2e/templates/java/radio/radio_javabuilddc.sh
+++ b/test/e2e/templates/java/radio/radio_javabuilddc.sh
@@ -17,7 +17,13 @@ set_app_main_class org.apache.spark.examples.JavaSparkPi
 # Need a little preamble here to read the resources.yaml, create the java template, and save
 # it to the resources directory
 set +e
-oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
+    echo Using local resource.yaml
+    oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
+else
+    echo Using https://radanalytics.io/resources.yaml
+    oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+fi
 oc export template oshinko-java-spark-build-dc -o json > $RESOURCE_DIR/oshinko-java-spark-build-dc.json
 fix_template $RESOURCE_DIR/oshinko-java-spark-build-dc.json radanalyticsio/radanalytics-java-spark $S2I_TEST_IMAGE_JAVA
 set -e

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -16,7 +16,13 @@ set_fixed_app_name pyspark-build
 # Need a little preamble here to read the resources.yaml, create the pyspark template, and save
 # it to the resources directory
 set +e
-oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
+    echo Using local resource.yaml
+    oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
+else
+    echo Using https://radanalytics.io/resources.yaml
+    oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+fi
 oc export template oshinko-pyspark-build-dc -o json > $RESOURCE_DIR/oshinko-pyspark-build-dc.json
 fix_template $RESOURCE_DIR/oshinko-pyspark-build-dc.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
 set -e

--- a/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/radio/radio_pysparkbuilddc.sh
@@ -17,7 +17,7 @@ set_fixed_app_name pyspark-build
 # it to the resources directory
 set +e
 if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
-    echo Using local resource.yaml
+    echo Using local resources.yaml
     oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
 else
     echo Using https://radanalytics.io/resources.yaml

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -17,7 +17,13 @@ set_app_main_class org.apache.spark.examples.SparkPi
 # Need a little preamble here to read the resources.yaml, create the scala template, and save
 # it to the resources directory
 set +e
-oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
+    echo Using local resource.yaml
+    oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
+else
+    echo Using https://radanalytics.io/resources.yaml
+    oc create -f https://radanalytics.io/resources.yaml &> /dev/null
+fi
 oc export template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
 fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark $S2I_TEST_IMAGE_SCALA
 set -e

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -18,7 +18,7 @@ set_app_main_class org.apache.spark.examples.SparkPi
 # it to the resources directory
 set +e
 if [ -f "$RESOURCE_DIR"/resources.yaml ]; then
-    echo Using local resource.yaml
+    echo Using local resources.yaml
     oc create -f $RESOURCE_DIR/resources.yaml &> /dev/null
 else
     echo Using https://radanalytics.io/resources.yaml


### PR DESCRIPTION
If a resources.yaml file is present in test/e2e/resources
(there is not one by default), the radio_* template tests
will use that file to create templates instead of using
https://radanalytics.io/resources.yaml.