### PR TITLE
Use 'date | md5sum' instead of 'cat /dev/urandom' as it hangs on some systems

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -120,7 +120,7 @@ function get_cluster_name {
             OSHINKO_CLUSTER_NAME=${output[0]}
             echo using stored cluster name $OSHINKO_CLUSTER_NAME
         else
-            OSHINKO_CLUSTER_NAME=cluster-`cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1`
+            OSHINKO_CLUSTER_NAME=cluster-`date -Ins | md5sum | tr -dc 'a-z0-9' | fold -w 6 | head -n 1`
         fi
     fi
 }

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -120,7 +120,7 @@ function set_defaults() {
 function run_app() {
     # Launch the app using the service account and create a cluster
     set +e
-    SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+    SUFFIX=$(date -Ins | md5sum | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
     set -e
     APP_NAME=app-$SUFFIX
     if [ "$#" -ne 1 ]; then
@@ -149,7 +149,7 @@ function run_job() {
     # Launch the app using the service account and create a cluster
     # Until jobs work with image triggers, we need the full pullspec for an image in a job template
     set +e
-    SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+    SUFFIX=$(date -Ins | md5sum | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
     set -e
     APP_NAME=app-$SUFFIX
     IMAGE_NAME=$(oc get is play --template="{{index .status \"dockerImageRepository\"}}")

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -77,7 +77,7 @@ for dir in "${dirs[@]}"; do
     # Create the project here
     name=$(basename ${dir} .sh)
     set +e # For some reason the result here from head is not 0 even though we get the desired result
-    namespace=${name}-$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 6 | head -n 1)
+    namespace=${name}-$(date -Ins | md5sum | tr -dc 'a-z0-9' | fold -w 6 | head -n 1)
     set -e
     oc new-project $namespace &> /dev/null
     oc create sa oshinko &> /dev/null

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -35,7 +35,7 @@ function set_defaults() {
 function app_preamble() {
     if [ -z "$FIXED_APP_NAME" -o "$RANDOM_NAME" == true ]; then
         set +e
-        SUFFIX=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
+        SUFFIX=$(date -Ins | md5sum | tr -dc 'a-z0-9' | fold -w 4 | head -n 1)
         set -e
         APP_NAME=app-$SUFFIX
     else


### PR DESCRIPTION
'cat /dev/urandom' caused problems on Jenkins