### PR TITLE
Update pysparkjob.json to use apiVersion batch/v1

### DIFF
--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -64,7 +64,7 @@
    ],
    "objects": [
       {
-          "apiVersion": "extensions/v1beta1",
+          "apiVersion": "batch/v1",
           "kind": "Job",
           "metadata": {
               "name": "${APPLICATION_NAME}"

--- a/pyspark/pysparkjob.json
+++ b/pyspark/pysparkjob.json
@@ -72,11 +72,6 @@
           "spec": {
               "completions": "${COMPLETIONS}",
               "parallelism": 1,
-              "selector": {
-                  "matchLabels": {
-                      "app": "${APPLICATION_NAME}"
-                  }
-              },
               "template": {
                   "metadata": {
                       "labels": {
@@ -117,9 +112,41 @@
                                 {
                                    "name": "OSHINKO_NAMED_CONFIG",
                                    "value": "${OSHINKO_NAMED_CONFIG}"
+                                },
+                                {
+                                   "name": "POD_NAME",
+                                   "valueFrom":
+                                     {
+                                        "fieldRef":
+                                           {
+                                              "fieldPath": "metadata.name"
+                                           }
+                                     }
+                                }
+                              ],
+                              "volumeMounts": [
+                                {
+                                   "mountPath": "/etc/podinfo",
+                                   "name": "podinfo",
+                                   "readOnly": false
                                 }
                               ]
                           }
+                      ],
+                      "volumes": [
+                         {
+                            "downwardAPI": {
+                               "items": [
+                                  {
+                                     "fieldRef": {
+                                        "fieldPath": "metadata.labels"
+                                     },
+                                     "path": "labels"
+                                  }
+                               ]
+                            },
+                            "name": "podinfo"
+                         }
                       ],
                       "restartPolicy": "Never",
                       "serviceAccount": "oshinko"


### PR DESCRIPTION
This will allow the job template to work with newer versions
of kubernetes/openshift (>= 3.6). Also add the downward
api items needed by latest s2i images.
