### PR TITLE
Make s2i images pull binary for oshinko CLI

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,29 +1,27 @@
 build: CMD=build
 clean: CMD=clean
 
-.PHONY: oshinko-cli process-driver-config
+.PHONY: process-driver-config
 
-export GOPATH = $(CURDIR)/oshinko-cli
-clonepath = $(CURDIR)/oshinko-cli/src/github.com/radanalyticsio
-makepath = $(clonepath)/oshinko-cli
+OSHINKO_RELEASE=v0.2.5
 
 # At this point utils is a simple directory which is copied
 # by other components, so handle it here rather than give it
 # a Makefile which we would want to exclude on a copy
-
-build: oshinko-cli process-driver-config
-	cp $(makepath)/_output/oshinko-cli utils
+build: oshinko_linux_amd64 process-driver-config
+	cp oshinko_linux_amd64/oshinko utils
 	cp process-driver-config/process-driver-config utils
 
 clean: 
-	rm -f utils/oshinko-cli
+	rm -f utils/oshinko
 	rm -f utils/process-driver-config
-	rm -rf $(clonepath)
-
-oshinko-cli:
-	- mkdir -p $(clonepath)
-	- cd $(clonepath) && git clone -b v0.2.3 https://github.com/radanalyticsio/oshinko-cli
-	cd $(makepath) && make extended
+	rm -rf oshinko_linux_amd64
+	rm -f oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
+ 
+oshinko_linux_amd64:
+	rm -f oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
+	wget https://github.com/radanalyticsio/oshinko-cli/releases/download/$(OSHINKO_RELEASE)/oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
+	tar -xvzf oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
 
 process-driver-config:
 	unset GOPATH

--- a/common/Makefile
+++ b/common/Makefile
@@ -20,8 +20,7 @@ clean:
  
 oshinko_linux_amd64:
 	rm -f oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
-	wget https://github.com/radanalyticsio/oshinko-cli/releases/download/$(OSHINKO_RELEASE)/oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
-	tar -xvzf oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz
+	curl -L https://github.com/radanalyticsio/oshinko-cli/releases/download/$(OSHINKO_RELEASE)/oshinko_$(OSHINKO_RELEASE)_linux_amd64.tar.gz | tar -zx
 
 process-driver-config:
 	unset GOPATH

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -31,7 +31,7 @@ function delete_ephemeral {
     local appstatus=$1
     local line
     echo "Deleting cluster $OSHINKO_CLUSTER_NAME"
-    line=$($CLI delete $OSHINKO_CLUSTER_NAME --app=$POD_NAME --app-status=$1 $CLI_ARGS 2>&1)
+    line=$($CLI delete_eph $OSHINKO_CLUSTER_NAME --app=$POD_NAME --app-status=$1 $CLI_ARGS 2>&1)
     echo $line
 }
 
@@ -114,7 +114,7 @@ function get_cluster_name {
     local lookup
     local output
     if [ -z "${OSHINKO_CLUSTER_NAME}" ]; then
-        lookup=$($CLI get --app=$DEPLOYMENT $CLI_ARGS 2>&1)
+        lookup=$($CLI get_eph --app=$DEPLOYMENT $CLI_ARGS 2>&1)
         if [ "$?" -eq 0 -a "$DEPLOYMENT" != "" ]; then
             output=($(echo $lookup))
             OSHINKO_CLUSTER_NAME=${output[0]}
@@ -213,7 +213,7 @@ function wait_for_workers_alive {
 source $APP_ROOT/etc/generate_container_user
 
 # Create the cluster through oshinko-cli if it does not exist
-CLI=$APP_ROOT/src/oshinko-cli
+CLI=$APP_ROOT/src/oshinko
 CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
 if [ "$KUBERNETES_SERVICE_PORT" -eq 443 ]; then                                                                                                           
@@ -246,7 +246,7 @@ if [ "$CLI_RES" -ne 0 ]; then
         echo "Didn't find cluster $OSHINKO_CLUSTER_NAME, creating shared cluster"
         APP_FLAG="--app=$POD_NAME"
     fi
-    CLI_LINE=$($CLI create $OSHINKO_CLUSTER_NAME --storedconfig=$OSHINKO_NAMED_CONFIG $APP_FLAG $CLI_ARGS 2>&1)
+    CLI_LINE=$($CLI create_eph $OSHINKO_CLUSTER_NAME --storedconfig=$OSHINKO_NAMED_CONFIG $APP_FLAG $CLI_ARGS 2>&1)
     CLI_RES=$?
     if [ "$CLI_RES" -eq 0 ]; then
         for i in {1..60}; do # wait up to 30 seconds

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -102,7 +102,7 @@ function poll_build() {
 	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
 	    echo Build for $APP_NAME status is $status, waiting ...
 	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
-	    oc log buildconfig/$APP_NAME
+	    oc log buildconfig/$APP_NAME | tail -100
 	    oc delete buildconfig $APP_NAME
 	    oc delete is $APP_NAME
 	    set +e


### PR DESCRIPTION
Instead of building the CLI in place, pull the release tarball
to get the binary. This will work starting with release v0.2.5
(but not any earlier release).