### PR TITLE
Add pysparkjob.json and pysparkdc.json to release_templates

### DIFF
--- a/release-templates.sh
+++ b/release-templates.sh
@@ -10,6 +10,7 @@ mkdir -p $TOP_DIR/release_templates
 rm -rf $TOP_DIR/release_templates/*
 
 cp $TOP_DIR/pyspark/pysparkbuild*.json $TOP_DIR/release_templates
+cp $TOP_DIR/pyspark/pysparkjob.json $TOP_DIR/pyspark/pysparkdc.json $TOP_DIR/release_templates
 cp $TOP_DIR/java/javabuild*.json $TOP_DIR/release_templates
 cp $TOP_DIR/scala/scalabuild*.json $TOP_DIR/release_templates
 


### PR DESCRIPTION
This is for completeness, even though they do not reference images directly.