### PR TITLE
Allow s2i tests to run against an external registry

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -34,12 +34,21 @@ The `test/e2e/common` file reads or sets several environment variables:
 ``S2I_TEST_INTEGRATED_REGISTRY``
 
   This is the IP address of the integrated registry and it needs to be set
-  when running tests against a full OpenShift instance. It does not need to
-  be set when running against an instance created with "oc cluster up".
+  when running tests against a full OpenShift instance from the OpenShift
+  master host and using the integrated registry. It does not need to be set
+  when running against an instance created with "oc cluster up".
 
 ```sh
 $ S2I_TEST_INTEGRATED_REGISTRY=172.123.456.89:5000 test/e2e/run.sh
 ```
+
+``S2I_TEST_EXTERNAL_REGISTRY``
+
+  This is the IP address of a docker registry to use as an alternative to
+  either the integrated registry or the local docker daemon when "oc cluster up"
+  is used to provide the OpenShift instance. If this is set then `S2I_TEST_EXTERNAL_USER`
+  and `S2I_TEST_EXTERNAL_PASSWORD` must also be set so that the tests can
+  log in to the registry.
 
 ``S2I_TEST_IMAGE`` (default is radanalytics-pyspark)
 

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -1,5 +1,8 @@
 #!/bin/bash
 S2I_TEST_INTEGRATED_REGISTRY=${S2I_TEST_INTEGRATED_REGISTRY:-}
+S2I_TEST_EXTERNAL_REGISTRY=${S2I_TEST_EXTERNAL_REGISTRY:-}
+S2I_TEST_EXTERNAL_USER=${S2I_TEST_EXTERNAL_USER:-}
+S2I_TEST_EXTERNAL_PASSWORD=${S2I_TEST_EXTERNAL_PASSWORD:-}
 
 if [ -z "$S2I_TEST_IMAGE_PYSPARK" ]; then
     if [ -n "$S2I_TEST_IMAGE_PREFIX" ]; then
@@ -41,10 +44,22 @@ RESOURCE_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)/resources
 source $(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i')/hack/lib/init.sh
 
 function print_test_env {
-    if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+    if [ -n "$S2I_TEST_EXTERNAL_REGISTRY" ]; then
+        echo Using external registry $S2I_TEST_EXTERNAL_REGISTRY
+        if [ -z "$S2I_TEST_EXTERNAL_USER" ]; then
+            echo "WARNING: S2I_TEST_EXTERNAL_USER not set!"
+        else
+	    echo Using external user $S2I_TEST_EXTERNAL_USER
+        fi
+        if [ -z "$S2I_TEST_EXTERNAL_PASSWORD" ]; then
+            echo "WARNING: S2I_TEST_EXTERNAL_PASSWORD not set!"
+        else
+            echo External password set
+        fi
+    elif [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
         echo Using integrated registry $S2I_TEST_INTEGRATED_REGISTRY
     else
-        echo Not using integrated registry
+        echo Not using external or integrated registry
     fi
     echo Using local s2i pyspark image $S2I_TEST_IMAGE_PYSPARK
     echo Using local s2i java image $S2I_TEST_IMAGE_JAVA
@@ -235,7 +250,32 @@ function make_image() {
             echo Uh oh, image $S2I_TEST_IMAGE_PYSPARK does not exist
             return 1
         fi
-        if [ -z "${S2I_TEST_INTEGRATED_REGISTRY}" ]; then
+
+	local user=
+	local password=
+	local pushproj=
+	local pushimage=
+	local registry=
+	local imagestream=
+
+	if [ -n  "$S2I_TEST_EXTERNAL_REGISTRY" ]; then
+	    user=$S2I_TEST_EXTERNAL_USER
+	    password=$S2I_TEST_EXTERNAL_PASSWORD
+	    pushproj=$user
+	    pushimage=scratch-radanalytics-pyspark
+	    registry=$S2I_TEST_EXTERNAL_REGISTRY
+	    imagestream=false
+
+	elif [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+	    user=$(oc whoami)
+	    password=$(oc whoami -t)
+	    pushproj=$PROJECT
+	    pushimage=radanalytics-pyspark
+	    registry=$S2I_TEST_INTEGRATED_REGISTRY
+	    imagestream=true
+	fi
+
+        if [ -z "$registry" ]; then
             os::cmd::expect_success 'oc new-build --name=play "$S2I_TEST_IMAGE_PYSPARK" --binary'
         else
             set +e
@@ -243,13 +283,17 @@ function make_image() {
             res=$?
             set -e
             if [ "$res" -eq 0 ]; then
-                docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+                docker login -u ${user} -e jack@jack.com -p ${password} ${registry}
             else
-                docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+                docker login -u ${user} -p ${password} ${registry}
             fi
-            docker tag ${S2I_TEST_IMAGE_PYSPARK} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
-            docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/radanalytics-pyspark
-            os::cmd::expect_success 'oc new-build --name=play --image-stream=radanalytics-pyspark --binary'
+            docker tag ${S2I_TEST_IMAGE_PYSPARK} ${registry}/${pushproj}/${pushimage}
+            docker push ${registry}/${pushproj}/${pushimage}
+	    if [ "$imagestream" == true ]; then
+		os::cmd::expect_success 'oc new-build --name=play --image-stream="$pushimage" --binary'
+	    else
+		os::cmd::expect_success 'oc new-build --name=play --docker-image="$pushproj"/"$pushimage" --binary'
+	    fi
         fi
     fi
     BUILDNUM=$(oc get buildconfig play --template='{{index .status "lastVersion"}}')

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -292,7 +292,7 @@ function make_image() {
 	    if [ "$imagestream" == true ]; then
 		os::cmd::expect_success 'oc new-build --name=play --image-stream="$pushimage" --binary'
 	    else
-		os::cmd::expect_success 'oc new-build --name=play --docker-image="$pushproj"/"$pushimage":latest --binary'
+		os::cmd::expect_success 'oc new-build --name=play --docker-image="$registry"/"$pushproj"/"$pushimage":latest --binary'
 	    fi
         fi
     fi

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -292,7 +292,7 @@ function make_image() {
 	    if [ "$imagestream" == true ]; then
 		os::cmd::expect_success 'oc new-build --name=play --image-stream="$pushimage" --binary'
 	    else
-		os::cmd::expect_success 'oc new-build --name=play --docker-image="$pushproj"/"$pushimage" --binary'
+		os::cmd::expect_success 'oc new-build --name=play --docker-image="$pushproj"/"$pushimage":latest --binary'
 	    fi
         fi
     fi

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -379,22 +379,50 @@ function fix_template() {
     local file=$1
     local original_image=$2
     local new_image=$3
+
+    local user=
+    local password=
+    local pushproj=
+    local pushimage=
+    local registry=
+    local imagestream=
+
     # If the integrated registry is defined, then we have to do a push of the local image
     # into the project and modify the template to use an ImageStreamTag
-    if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+    if [ -n  "$S2I_TEST_EXTERNAL_REGISTRY" ]; then
+	user=$S2I_TEST_EXTERNAL_USER
+	password=$S2I_TEST_EXTERNAL_PASSWORD
+	pushproj=$user
+	pushimage=scratch-$new_image
+	registry=$S2I_TEST_EXTERNAL_REGISTRY
+	imagestream=false
+    elif [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+	user=$(oc whoami)
+	password=$(oc whoami -t)
+	pushproj=$PROJECT
+	pushimage=$new_image
+	registry=$S2I_TEST_INTEGRATED_REGISTRY
+	imagestream=true
+    fi
+
+    if [ -n "$registry" ]; then
         set +e
         docker login --help | grep email &> /dev/null
         local res=$?
         set -e
         if [ "$res" -eq 0 ]; then
-            docker login -u $(oc whoami) -e jack@jack.com -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+            docker login -u $user -e jack@jack.com -p $password $registry
         else
-            docker login -u $(oc whoami) -p $(oc whoami -t) ${S2I_TEST_INTEGRATED_REGISTRY}
+            docker login -u $user -p $password $registry
         fi
-        docker tag ${new_image} ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
-        docker push ${S2I_TEST_INTEGRATED_REGISTRY}/${PROJECT}/${new_image}
-        sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
-        sed -i "s^\"name\": \"$original_image\"^\"name\": \"$new_image:latest\"^" $file
+        docker tag ${new_image} ${registry}/${pushproj}/${pushimage}
+        docker push ${registry}/${pushproj}/${pushimage}
+        if [ "$imagestream" == true ]; then
+            sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
+            sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushimage:latest\"^" $file
+        else
+            sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushproj/$pushimage\"^" $file
+        fi
 
     # if the integrated registry is not defined then we just use DockerImage with the local image
     # and remove the forcePull (forcePull will break the ability of "oc cluster up" to grab the local image)
@@ -412,13 +440,34 @@ function check_image {
     os::cmd::try_until_success 'oc get buildconfig "$APP_NAME"' $((10*minute))
     IMAGE=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "name"}}')
     KIND=$(oc get buildconfig $APP_NAME --template='{{index .spec "strategy" "sourceStrategy" "from" "kind"}}')
-    if [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+
+    local pushproj=
+    local pushimage=
+    local registry=
+    local imagestream=
+
+    # If the integrated registry is defined, then we have to do a push of the local image
+    # into the project and modify the template to use an ImageStreamTag
+    if [ -n  "$S2I_TEST_EXTERNAL_REGISTRY" ]; then
+	imagestream=false
+	registry=true
+	testimage=$S2I_TEST_EXTERNAL_USER/scratch-$testimage
+    elif [ -n "$S2I_TEST_INTEGRATED_REGISTRY" ]; then
+	imagestream=true
+	registry=true
+    fi
+
+    if [ "$registry" == true ]; then
         # strip the tags from both images in the case of the integrated registry
         # because we're not sure what we'll have.
         v1=$(echo "$IMAGE" | sed -r -e "s@([^:]*)(:.*)@\1@")
         v2=$(echo "$testimage" | sed -r -e "s@([^:]*)(:.*)@\1@")
+        echo $v1
+        echo $v2
         os::cmd::expect_success '[ "$v1" == "$v2" ]'
-        os::cmd::expect_success '[ "$KIND" == "ImageStreamTag" ]'
+        if [ "$imagestream" == true ]; then
+            os::cmd::expect_success '[ "$KIND" == "ImageStreamTag" ]'
+        fi
     else
         os::cmd::expect_success '[ "$IMAGE" == "$testimage" ]'
         os::cmd::expect_success '[ "$KIND" == "DockerImage" ]'


### PR DESCRIPTION
This change adds environment variables for setting up the tests to run against an external registry.  If the external registry env var is set, it will take precedence over S2I_TEST_INTEGRATED_REGISTRY.

Set all of these to use an external registry:

S2I_TEST_EXTERNAL_REGISTRY (ie, docker.io)
S2I_TEST_EXTERNAL_USER (ie, bob)
S2I_TEST_EXTERNAL_PASSWORD (bob's password)

The tests will create various images starting with "scratch",
for example "scratch-pyspark", "scratch-radanalytics-pyspark",
"scratch-radanalytics-java-spark", etc.