### PR TITLE
Make default timeout five minutes for tests

### DIFF
--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -101,6 +101,7 @@ readonly -f os::cmd::expect_code_and_not_text
 millisecond=1
 second=$(( 1000 * millisecond ))
 minute=$(( 60 * second ))
+fiveminute=$(( 300 * second ))
 
 # os::cmd::try_until_success runs the cmd in a small interval until either the command succeeds or times out
 # the default time-out for os::cmd::try_until_success is 60 seconds.
@@ -108,8 +109,8 @@ minute=$(( 60 * second ))
 function os::cmd::try_until_success() {
 	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_success expects at least one arguments, got $#"; return 1; fi
 	local cmd=$1
-	local duration=${2:-minute}
-	local interval=${3:-0.2}
+	local duration=${2:-fiveminute}
+	local interval=${3:-0.5}
 
 	os::cmd::internal::run_until_exit_code "${cmd}" "os::cmd::internal::success_func" "${duration}" "${interval}"
 }
@@ -120,8 +121,8 @@ readonly -f os::cmd::try_until_success
 function os::cmd::try_until_failure() {
 	if [[ $# -lt 1 ]]; then echo "os::cmd::try_until_failure expects at least one argument, got $#"; return 1; fi
 	local cmd=$1
-	local duration=${2:-$minute}
-	local interval=${3:-0.2}
+	local duration=${2:-$fiveminute}
+	local interval=${3:-0.5}
 
 	os::cmd::internal::run_until_exit_code "${cmd}" "os::cmd::internal::failure_func" "${duration}" "${interval}"
 }
@@ -133,8 +134,8 @@ function os::cmd::try_until_text() {
 	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_text expects at least two arguments, got $#"; return 1; fi
 	local cmd=$1
 	local text=$2
-	local duration=${3:-minute}
-	local interval=${4:-0.2}
+	local duration=${3:-fiveminute}
+	local interval=${4:-0.5}
 
 	os::cmd::internal::run_until_text "${cmd}" "${text}" "os::cmd::internal::success_func" "${duration}" "${interval}"
 }
@@ -146,8 +147,8 @@ function os::cmd::try_until_not_text() {
 	if [[ $# -lt 2 ]]; then echo "os::cmd::try_until_not_text expects at least two arguments, got $#"; return 1; fi
 	local cmd=$1
 	local text=$2
-	local duration=${3:-minute}
-	local interval=${4:-0.2}
+	local duration=${3:-fiveminute}
+	local interval=${4:-0.5}
 
 	os::cmd::internal::run_until_text "${cmd}" "${text}" "os::cmd::internal::failure_func" "${duration}" "${interval}"
 }


### PR DESCRIPTION
This change modifies all of the "try_until" variants in the
test lib so that the default timeout is 5 minutes with a
0.5 second repeat rate. The goal is to see if this helps
Jenkins tests.