### PR TITLE
Add a workaround for image build fails in e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,10 @@ script:
 - if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.java . ; fi
 - if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.scala . ; fi
 
-- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; make test-ephemeral ; fi
-- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; make test-pyspark-templates ; fi
-- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; make test-java-templates ; fi
-- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; make test-scala-templates ; fi
+- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; travis-retry-make.sh test-ephemeral ; fi
+- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-pyspark-templates ; fi
+- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-java-templates ; fi
+- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-scala-templates ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,8 @@ before_install:
       if [ "$built" == false ]; then
           exit 1
       fi
-
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
-      oc describe dc/docker-registry
-      oc describe dc/router
+      # travis-check-pods.sh left us in the default project
+      oc get pods
       oc project myproject     
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,9 @@ script:
 - if [ "$TO_TEST" == "scala-templates" ]; then pushd `pwd`; cd scala; make build; popd ; fi
 
 - if [ "$TO_TEST" == "ephemeral" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "(ephemeral|incomplete)" ; fi
-- if [ "$TO_TEST" == "pyspark-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "pyspark/templates" ; fi
-- if [ "$TO_TEST" == "java-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "java/templates" ; fi
-- if [ "$TO_TEST" == "scala-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "scala/templates" ; fi
+- if [ "$TO_TEST" == "pyspark-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "templates/pyspark" ; fi
+- if [ "$TO_TEST" == "java-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "templates/java" ; fi
+- if [ "$TO_TEST" == "scala-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "templates/scala" ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,10 @@ script:
 - if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.java . ; fi
 - if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.scala . ; fi
 
-- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; travis-retry-make.sh test-ephemeral ; fi
-- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-pyspark-templates ; fi
-- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-java-templates ; fi
-- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; travis-retry-make.sh test-scala-templates ; fi
+- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-ephemeral ; fi
+- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-pyspark-templates ; fi
+- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-java-templates ; fi
+- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-scala-templates ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,10 @@ before_install:
       echo ${IP}
       IPSTR=`sudo oc login -u system:admin`
       echo $IPSTR
+      oc project default
       oc describe dc/docker-registry
-      oc describe dc/router     
+      oc describe dc/router
+      oc project myproject     
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,8 @@ before_install:
       echo ${IP}
       IPSTR=`sudo oc login -u system:admin`
       echo $IPSTR
+      oc describe dc/docker-registry
+      oc describe dc/router     
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,14 +86,14 @@ before_install:
 install:
 before_script:
 script:
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.pyspark . ; fi
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.java . ; fi
-- if [ "$TO_TEST" = "build" ]; then docker build -f Dockerfile.scala . ; fi
+- if [ "$TO_TEST" == "ephemeral" -o "$TO_TEST" == "pyspark-templates" ]; then pushd `pwd`; cd pyspark; make build; popd ; fi
+- if [ "$TO_TEST" == "java-templates" ]; then pushd `pwd`; cd java; make build; popd ; fi
+- if [ "$TO_TEST" == "scala-templates" ]; then pushd `pwd`; cd scala; make build; popd ; fi
 
-- if [ "$TO_TEST" = "ephemeral" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-ephemeral ; fi
-- if [ "$TO_TEST" = "pyspark-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-pyspark-templates ; fi
-- if [ "$TO_TEST" = "java-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-java-templates ; fi
-- if [ "$TO_TEST" = "scala-templates" ]; then export TEST_ONLY=1; ./travis-retry-make.sh test-scala-templates ; fi
+- if [ "$TO_TEST" == "ephemeral" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "(ephemeral|incomplete)" ; fi
+- if [ "$TO_TEST" == "pyspark-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "pyspark/templates" ; fi
+- if [ "$TO_TEST" == "java-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "java/templates" ; fi
+- if [ "$TO_TEST" == "scala-templates" ]; then export TEST_ONLY=1; ./travis-retry-run.sh "scala/templates" ; fi
 notifications:
  email:
    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,35 +53,31 @@ before_install:
       echo $PATH
       # below cmd is important to get oc working in ubuntu
       sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v1.5.1 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
+      sudo chmod -R a+rwX /home/travis/.kube
 
       # Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
       # See if a retry within the same test works
       set +e
       built=false
-      for tries in {1..3}; do
-          sudo oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+      while true; do
+          oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
           if [ "$?" -eq 0 ]; then
-              built=true
-              break
+              ./travis-check-pods.sh
+              if [ "$?" -eq 0 ]; then
+                  built=true
+                  break
+              fi
           fi
           echo "Retrying oc cluster up after failure"
-          sudo oc cluster down
+          oc cluster down
+          sleep 5
       done
       set -e
       if [ "$built" == false ]; then
           exit 1
       fi
 
-      sudo chmod -R a+rwX /home/travis/.kube
       sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
-      # find IP:PORT of openshift
-      IPSTR=`sudo oc status |grep server`
-      echo $IPSTR
-      IP=${IPSTR##*/}
-      echo ${IP}
-      IPSTR=`sudo oc login -u system:admin`
-      echo $IPSTR
-      oc project default
       oc describe dc/docker-registry
       oc describe dc/router
       oc project myproject     

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -253,18 +253,62 @@ function cleanup_cluster() {
 #    fi
 } 
 
+function poll_build() {
+    local name
+    if [ "$#" -eq 1 ]; then
+	name=$1
+    else
+	name=$APP_NAME
+    fi
+    local tries=0
+    local status
+    local BUILDNUM=$(oc get buildconfig $name --template='{{index .status "lastVersion"}}')
+    while true; do
+        status=$(oc get build "$name"-$BUILDNUM --template="{{index .status \"phase\"}}")
+	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
+	    echo Build for $name status is $status, waiting ...
+	    sleep 10
+	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
+	    oc log buildconfig/$name | tail -100
+	    if [ "$tries" -lt 4 ]; then
+		tries=$((tries+1))
+	        echo "Trying build again..."
+		oc start-build $name
+		sleep 10
+	    else
+		echo "Retries exhausted ..."
+	        oc delete buildconfig $name
+	        oc delete is $name
+	        set +e
+	        oc delete dc $name
+	        set -e
+	        return 1
+	    fi
+	else
+	    break
+	fi
+    done
+}
+
 function make_image() {
     TEST_IMAGE=play
     set +e
     oc get buildconfig play &> /dev/null
     local res=$?
     set -e
+
+    # If we found the buildconfig for play, then the build
+    # succeeded because we would have deleted it last time in poll_build
+    # if it ultimately failed with retries. So we're good.
+
+    # If not, build it from scratch with retries
+
     if [ "$res" -ne 0 ]; then
-        # The ip address of the internal registry may be set to support running against
+        # The ip address of an internal/external registry may be set to support running against
         # an openshift that is not "oc cluster up". In the case of "oc cluster up", the docker
         # on the host is available from openshift so no special pushes of images have to be done.
         # In the case of a "normal" openshift cluster, the image we'll use for build has to be
-        # available as an imagestream.
+        # available from the designated registry.
         set +e
         tmp=$(docker history $S2I_TEST_IMAGE_PYSPARK)
         res=$?
@@ -318,25 +362,8 @@ function make_image() {
 		os::cmd::expect_success 'oc new-build --name=play --docker-image="$registry"/"$pushproj"/"$pushimage":latest --binary'
 	    fi
         fi
+	os::cmd::expect_success 'oc start-build play --from-file="$RESOURCE_DIR"/play'
+	poll_build play
+	return $?
     fi
-    BUILDNUM=$(oc get buildconfig play --template='{{index .status "lastVersion"}}')
-    set +e
-    oc get build play-$BUILDNUM &> /dev/null
-    res=$?
-    set -e
-    if [ "$res" -eq 0 ]; then
-        # Make sure that the build is complete. If not, start another one.
-	phase=$(oc get build play-$BUILDNUM --template="{{index .status \"phase\"}}")
-        if [ "$phase" != "Running" -a "$phase" != "Complete" ]; then
-            echo "Build phase for play-$BUILDNUM is $phase, restarting..."
-            res=1
-        fi
-    fi
-    if [ "$res" -ne 0 ]; then
-        os::cmd::expect_success 'oc start-build play --from-file="$RESOURCE_DIR"/play'
-        BUILDNUM=$(oc get buildconfig play --template='{{index .status "lastVersion"}}')
-        oc logs -f buildconfig/play
-    fi
-    # Wait for the build to finish
-    os::cmd::try_until_text 'oc get build play-"$BUILDNUM" --template="{{index .status \"phase\"}}"' "Complete" $((5*minute))
 }

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -269,12 +269,14 @@ function poll_build() {
 	    echo Build for $name status is $status, waiting ...
 	    sleep 10
 	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
+	    set +e
 	    oc log buildconfig/$name | tail -100
-	    if [ "$tries" -lt 4 ]; then
+	    set -e
+	    if [ "$tries" -lt 10 ]; then
 		tries=$((tries+1))
 	        echo "Trying build again..."
 		oc start-build $name
-		sleep 10
+		sleep 30
 	    else
 		echo "Retries exhausted ..."
 	        oc delete buildconfig $name

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -270,22 +270,20 @@ function poll_build() {
 	    sleep 10
 	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
 	    set +e
+	    oc log buildconfig/$name | grep "Failed to push image.*connection refused"
+	    if [ "$?" -eq 0 ]; then
+		# Write FAIL_ON_PUSH to a file so that the overseeing process
+		# can know that this happened
+                echo FAIL_ON_PUSH=true > $TEST_DIR/failonpush
+	    fi
 	    oc log buildconfig/$name | tail -100
 	    set -e
-	    if [ "$tries" -lt 10 ]; then
-		tries=$((tries+1))
-	        echo "Trying build again..."
-		oc start-build $name
-		sleep 30
-	    else
-		echo "Retries exhausted ..."
-	        oc delete buildconfig $name
-	        oc delete is $name
-	        set +e
-	        oc delete dc $name
-	        set -e
-	        return 1
-	    fi
+	    oc delete buildconfig $name
+	    oc delete is $name
+	    set +e
+	    oc delete dc $name
+	    set -e
+	    return 1
 	else
 	    break
 	fi

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -94,28 +94,6 @@ function set_app_main_class() {
     fi
 }
 
-function poll_build() {
-    local status
-    local BUILDNUM=$(oc get buildconfig $APP_NAME --template='{{index .status "lastVersion"}}')
-    while true; do
-        status=$(oc get build "$APP_NAME"-$BUILDNUM --template="{{index .status \"phase\"}}")
-	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
-	    echo Build for $APP_NAME status is $status, waiting ...
-	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
-	    oc log buildconfig/$APP_NAME | tail -100
-	    oc delete buildconfig $APP_NAME
-	    oc delete is $APP_NAME
-	    set +e
-	    oc delete dc $APP_NAME
-	    set -e
-	    return 1
-	else
-	    break
-	fi
-	sleep 30
-    done
-}
-
 function run_app() {
     app_preamble
     set +e

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -38,7 +38,7 @@ while true; do
 done
 
 while true; do
-    V=$(oc get dc docker-registry --template='{{index .status "latestVersion"}}')
+    V=$(oc get dc router --template='{{index .status "latestVersion"}}')
     P=$(oc get pod router-$V-deploy --template='{{index .status "phase"}}')
     if [ "$?" -eq 0 ]; then
         echo phase is $P for router deploy $V

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -7,7 +7,7 @@ while true; do
     ERR=$(oc get pods | grep docker-registry.*deploy.*Error)
     if [ "$?" -eq 0 ]; then
         echo "registry deploy failed, try again"
-        oc deploy dc docker-registry --latest
+        oc deploy dc/docker-registry --latest
         sleep 5
         continue
     fi
@@ -36,7 +36,7 @@ while true; do
     ERR=$(oc get pods | grep router.*deploy.*Error)
     if [ "$?" -eq 0 ]; then
         echo "router deploy failed, try again"
-        oc deploy dc router --latest
+        oc deploy dc/router --latest
         sleep 5
         continue
     fi

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -5,6 +5,15 @@ oc project default
 
 while true; do
     REG=$(oc get pod -l deploymentconfig=docker-registry --template='{{index .items 0 "status" "phase"}}')
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+    echo "Waiting for registry pod"
+    sleep 10
+done
+
+while true; do
+    REG=$(oc get pod -l deploymentconfig=docker-registry --template='{{index .items 0 "status" "phase"}}')
     if [ "$?" -ne 0 -o "$REG" == "Error" ]; then
         echo "Registy pod is in error state..."
         exit 1
@@ -12,7 +21,18 @@ while true; do
     if [ "$REG" == "Running" ]; then
         break
     fi
+    sleep 5
 done
+
+while true; do
+    REG=$(oc get pod -l deploymentconfig=router --template='{{index .items 0 "status" "phase"}}')
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+    echo "Waiting for registry pod"
+    sleep 10
+done
+
 
 while true; do
     REG=$(oc get pod -l deploymentconfig=router --template='{{index .items 0 "status" "phase"}}')
@@ -23,5 +43,6 @@ while true; do
     if [ "$REG" == "Running" ]; then
         break
     fi
+    sleep 5
 done
 echo "Registry and router pods are okay"

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+oc login -u system:admin
+oc project default
+
+while true; do
+    REG=$(oc get pod -l deploymentconfig=docker-registry --template='{{index .items 0 "status" "phase"}}')
+    if [ "$?" -ne 0 -o "$REG" == "Error" ]; then
+        echo "Registy pod is in error state..."
+        exit 1
+    fi
+    if [ "$REG" == "Running" ]; then
+        break
+    fi
+done
+
+while true; do
+    REG=$(oc get pod -l deploymentconfig=router --template='{{index .items 0 "status" "phase"}}')
+    if [ "$?" -ne 0 -o "$REG" == "Error" ]; then
+        echo "Router pod is in error state..."
+        exit 1
+    fi
+    if [ "$REG" == "Running" ]; then
+        break
+    fi
+done
+echo "Registry and router pods are okay"

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -8,7 +8,7 @@ while true; do
     if [ "$?" -eq 0 ]; then
         echo "registry deploy failed, try again"
         oc get pods
-        oc deploy dc/docker-registry --latest
+        oc rollout dc/docker-registry --retry
         sleep 5
         continue
     fi
@@ -38,7 +38,7 @@ while true; do
     if [ "$?" -eq 0 ]; then
         echo "router deploy failed, try again"
         oc get pods
-        oc deploy dc/router --latest
+        oc rollout dc/router --retry
         sleep 5
         continue
     fi

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -8,7 +8,7 @@ while true; do
     P=$(oc get pod docker-registry-$V-deploy --template='{{index .status "phase"}}')
     if [ "$?" -eq 0 ]; then
         echo phase is $P for docker-registry deploy $V
-        if [ "$P" == "Error" ]; then
+        if [ "$P" == "Failed" ]; then
             echo "registry deploy failed, try again"
             oc get pods
             oc rollout dc/docker-registry --retry
@@ -42,7 +42,7 @@ while true; do
     P=$(oc get pod router-$V-deploy --template='{{index .status "phase"}}')
     if [ "$?" -eq 0 ]; then
         echo phase is $P for router deploy $V
-        if [ "$P" == "Error" ]; then
+        if [ "$P" == "Failed" ]; then
             echo "router deploy failed, try again"
             oc get pods
             oc rollout dc/router --retry

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -8,6 +8,7 @@ while true; do
     if [ "$?" -eq 0 ]; then
         break
     fi
+    oc get pods
     echo "Waiting for registry pod"
     sleep 10
 done
@@ -29,7 +30,8 @@ while true; do
     if [ "$?" -eq 0 ]; then
         break
     fi
-    echo "Waiting for registry pod"
+    oc get pods
+    echo "Waiting for router pod"
     sleep 10
 done
 

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#oc login -u system:admin
-#oc project default
+oc login -u system:admin
+oc project default
 
 while true; do
     V=$(oc get dc docker-registry --template='{{index .status "latestVersion"}}')

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -43,9 +43,9 @@ while true; do
     if [ "$?" -eq 0 ]; then
         echo phase is $P for router deploy $V
         if [ "$P" == "Error" ]; then
-            echo "registry deploy failed, try again"
+            echo "router deploy failed, try again"
             oc get pods
-            oc rollout dc/docker-registry --retry
+            oc rollout dc/router --retry
             sleep 10
             continue
         fi

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -7,6 +7,7 @@ while true; do
     ERR=$(oc get pods | grep docker-registry.*deploy.*Error)
     if [ "$?" -eq 0 ]; then
         echo "registry deploy failed, try again"
+        oc get pods
         oc deploy dc/docker-registry --latest
         sleep 5
         continue
@@ -36,6 +37,7 @@ while true; do
     ERR=$(oc get pods | grep router.*deploy.*Error)
     if [ "$?" -eq 0 ]; then
         echo "router deploy failed, try again"
+        oc get pods
         oc deploy dc/router --latest
         sleep 5
         continue

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -4,6 +4,13 @@ oc login -u system:admin
 oc project default
 
 while true; do
+    ERR=$(oc get pods | grep docker-registry.*deploy.*Error)
+    if [ "$?" -eq 0 ]; then
+        echo "registry deploy failed, try again"
+        oc deploy dc docker-registry --latest
+        sleep 5
+        continue
+    fi
     REG=$(oc get pod -l deploymentconfig=docker-registry --template='{{index .items 0 "status" "phase"}}')
     if [ "$?" -eq 0 ]; then
         break
@@ -26,6 +33,13 @@ while true; do
 done
 
 while true; do
+    ERR=$(oc get pods | grep router.*deploy.*Error)
+    if [ "$?" -eq 0 ]; then
+        echo "router deploy failed, try again"
+        oc deploy dc router --latest
+        sleep 5
+        continue
+    fi
     REG=$(oc get pod -l deploymentconfig=router --template='{{index .items 0 "status" "phase"}}')
     if [ "$?" -eq 0 ]; then
         break

--- a/travis-check-pods.sh
+++ b/travis-check-pods.sh
@@ -11,7 +11,7 @@ while true; do
         if [ "$P" == "Failed" ]; then
             echo "registry deploy failed, try again"
             oc get pods
-            oc rollout dc/docker-registry --retry
+            oc rollout retry dc/docker-registry
             sleep 10
             continue
         fi
@@ -45,7 +45,7 @@ while true; do
         if [ "$P" == "Failed" ]; then
             echo "router deploy failed, try again"
             oc get pods
-            oc rollout dc/router --retry
+            oc rollout retry dc/router
             sleep 10
             continue
         fi

--- a/travis-cup.sh
+++ b/travis-cup.sh
@@ -8,6 +8,7 @@ for tries in {1..3}; do
     sudo oc cluster up # --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
     if [ "$?" -eq 0 ]; then
         built=true
+        oc login -u system:admin
         break
     fi
     echo "Retrying oc cluster up after failure"

--- a/travis-cup.sh
+++ b/travis-cup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
+# See if a retry within the same test works
+set +e
+built=false
+for tries in {1..3}; do
+    sudo oc cluster up # --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+    if [ "$?" -eq 0 ]; then
+        built=true
+        break
+    fi
+    echo "Retrying oc cluster up after failure"
+    sudo oc cluster down
+done
+set -e
+if [ "$built" == false ]; then
+    exit 1
+fi

--- a/travis-retry-make.sh
+++ b/travis-retry-make.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+FAIL_ON_PUSH=false
+
+while true; do
+    set +e
+    make $1
+    makeres=$?
+    set -e
+    if [ "$makeres" -ne 0 ]; then
+	set +e
+        source test/e2e/failonpush
+	set -e
+        if [ "$FAIL_ON_PUSH" == true ]; then
+            echo "failed on push, going to retry"
+            sleep 5
+	    sudo oc cluster down
+	    ./travis-cup.sh
+	    sudo chmod -R a+rwX /home/travis/.kube
+        else
+            exit $makeres
+        fi
+    else
+        break
+    fi
+done

--- a/travis-retry-run.sh
+++ b/travis-retry-run.sh
@@ -4,7 +4,7 @@ FAIL_ON_PUSH=false
 
 while true; do
     set +e
-    make $1
+    test/e2e/run.sh $1
     makeres=$?
     set -e
     if [ "$makeres" -ne 0 ]; then

--- a/travis-retry-run.sh
+++ b/travis-retry-run.sh
@@ -3,6 +3,8 @@
 FAIL_ON_PUSH=false
 
 while true; do
+    oc project default
+    oc get pods
     set +e
     test/e2e/run.sh $1
     makeres=$?

--- a/travis-retry-run.sh
+++ b/travis-retry-run.sh
@@ -5,6 +5,8 @@ FAIL_ON_PUSH=false
 while true; do
     oc project default
     oc get pods
+    oc describe dc/docker-registry
+    oc describe dc/router
     set +e
     test/e2e/run.sh $1
     makeres=$?


### PR DESCRIPTION
Especially in the Travis environment, image pushes from
s2i builder pods seem to routinely fail.

* Add a retry loop in poll_build to retry a build up to 5 times before
  giving up
* Add a call to poll_build from make_image when building
  the common "play" imagestream used by ephemeral tests.