### PR TITLE
Add a retry on s2i builds that fail during Push for tests

### DIFF
--- a/test/e2e/common
+++ b/test/e2e/common
@@ -264,7 +264,7 @@ function poll_build() {
     local status
     local BUILDNUM
     while true; do
-	BUILDNUM=$(oc get buildconfig $name --template='{{index .status "lastVersion"}}')
+        BUILDNUM=$(oc get buildconfig $name --template='{{index .status "lastVersion"}}')
         status=$(oc get build "$name"-$BUILDNUM --template="{{index .status \"phase\"}}")
 	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
 	    echo Build for $name-$BUILDNUM status is $status, waiting ...
@@ -274,7 +274,7 @@ function poll_build() {
 	    oc log buildconfig/$name | grep "Pushing image"
 	    if [ "$?" -eq 0 ]; then
 		tries=$((tries+1))
-		if [ "$tries" -lt 2 ]; then
+		if [ "$tries" -lt 5 ]; then
 		    echo Build failed on push, retrying
 		    sleep 5
 		    oc start-build $name

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -253,18 +253,67 @@ function cleanup_cluster() {
 #    fi
 } 
 
+function poll_build() {
+    local name
+    if [ "$#" -eq 1 ]; then
+	name=$1
+    else
+	name=$APP_NAME
+    fi
+    local tries=0
+    local status
+    local BUILDNUM
+    while true; do
+	BUILDNUM=$(oc get buildconfig $name --template='{{index .status "lastVersion"}}')
+        status=$(oc get build "$name"-$BUILDNUM --template="{{index .status \"phase\"}}")
+	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
+	    echo Build for $name-$BUILDNUM status is $status, waiting ...
+	    sleep 10
+	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
+	    set +e
+	    oc log buildconfig/$name | grep "Pushing image"
+	    if [ "$?" -eq 0 ]; then
+		tries=$((tries+1))
+		if [ "$tries" -lt 2 ]; then
+		    echo Build failed on push, retrying
+		    sleep 5
+		    oc start-build $name
+		    continue
+		fi
+	    fi
+	    oc log buildconfig/$name | tail -100
+	    set -e
+	    oc delete buildconfig $name
+	    oc delete is $name
+	    set +e
+	    oc delete dc $name
+	    set -e
+	    return 1
+	else
+	    break
+	fi
+    done
+}
+
 function make_image() {
     TEST_IMAGE=play
     set +e
     oc get buildconfig play &> /dev/null
     local res=$?
     set -e
+
+    # If we found the buildconfig for play, then the build
+    # succeeded because we would have deleted it last time in poll_build
+    # if it ultimately failed with retries. So we're good.
+
+    # If not, build it from scratch with retries
+
     if [ "$res" -ne 0 ]; then
-        # The ip address of the internal registry may be set to support running against
+        # The ip address of an internal/external registry may be set to support running against
         # an openshift that is not "oc cluster up". In the case of "oc cluster up", the docker
         # on the host is available from openshift so no special pushes of images have to be done.
         # In the case of a "normal" openshift cluster, the image we'll use for build has to be
-        # available as an imagestream.
+        # available from the designated registry.
         set +e
         tmp=$(docker history $S2I_TEST_IMAGE_PYSPARK)
         res=$?
@@ -318,25 +367,11 @@ function make_image() {
 		os::cmd::expect_success 'oc new-build --name=play --docker-image="$registry"/"$pushproj"/"$pushimage":latest --binary'
 	    fi
         fi
+	os::cmd::expect_success 'oc start-build play --from-file="$RESOURCE_DIR"/play'
+	poll_build play
+	if [ "$?" -ne 0 ]; then
+	    echo make_image failed, exiting
+	    exit 1
+	fi
     fi
-    BUILDNUM=$(oc get buildconfig play --template='{{index .status "lastVersion"}}')
-    set +e
-    oc get build play-$BUILDNUM &> /dev/null
-    res=$?
-    set -e
-    if [ "$res" -eq 0 ]; then
-        # Make sure that the build is complete. If not, start another one.
-	phase=$(oc get build play-$BUILDNUM --template="{{index .status \"phase\"}}")
-        if [ "$phase" != "Running" -a "$phase" != "Complete" ]; then
-            echo "Build phase for play-$BUILDNUM is $phase, restarting..."
-            res=1
-        fi
-    fi
-    if [ "$res" -ne 0 ]; then
-        os::cmd::expect_success 'oc start-build play --from-file="$RESOURCE_DIR"/play'
-        BUILDNUM=$(oc get buildconfig play --template='{{index .status "lastVersion"}}')
-        oc logs -f buildconfig/play
-    fi
-    # Wait for the build to finish
-    os::cmd::try_until_text 'oc get build play-"$BUILDNUM" --template="{{index .status \"phase\"}}"' "Complete" $((5*minute))
 }

--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -94,28 +94,6 @@ function set_app_main_class() {
     fi
 }
 
-function poll_build() {
-    local status
-    local BUILDNUM=$(oc get buildconfig $APP_NAME --template='{{index .status "lastVersion"}}')
-    while true; do
-        status=$(oc get build "$APP_NAME"-$BUILDNUM --template="{{index .status \"phase\"}}")
-	if [ "$status" != "Complete" -a "$status" != "Failed" -a "$status" != "Error" ]; then
-	    echo Build for $APP_NAME status is $status, waiting ...
-	elif [ "$status" == "Failed" -o "$status" == "Error" ]; then
-	    oc log buildconfig/$APP_NAME | tail -100
-	    oc delete buildconfig $APP_NAME
-	    oc delete is $APP_NAME
-	    set +e
-	    oc delete dc $APP_NAME
-	    set -e
-	    return 1
-	else
-	    break
-	fi
-	sleep 30
-    done
-}
-
 function run_app() {
     app_preamble
     set +e
@@ -131,6 +109,7 @@ function run_app() {
     if [ "$#" -eq 0 ]; then
 	if [ "$stream_exists" -ne 0 ]; then
             poll_build
+	    return $?
 	fi
         os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'Using.*cluster' $((10*minute))
     fi
@@ -144,7 +123,8 @@ function run_app_without_optionals() {
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME -p OSHINKO_CLUSTER_NAME=$GEN_CLUSTER_NAME $APP_MAIN_CLASS &> /dev/null
     set -e
     if [ "$stream_exists" -ne 0 ]; then
-       poll_build
+	poll_build
+	return $?
     fi
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'Using.*cluster'  $((10*minute))
 }
@@ -157,7 +137,8 @@ function run_app_without_clustername() {
     oc new-app --file=$TEMPLATE $SOURCE_INFO -p APPLICATION_NAME=$APP_NAME $APP_MAIN_CLASS &> /dev/null
     set -e
     if [ "$stream_exists" -ne 0 ]; then
-       poll_build
+	poll_build
+	return $?
     fi
     os::cmd::try_until_text 'oc logs dc/"$APP_NAME"' 'Using.*cluster'  $((10*minute))
 }

--- a/test/e2e/templates/buildonly
+++ b/test/e2e/templates/buildonly
@@ -13,6 +13,7 @@ function run_app() {
     if [ "$#" -eq 0 ]; then
         if [ "$stream_exists" -ne 0 ]; then
             poll_build
+	    return $?
         fi
     fi
     set -e


### PR DESCRIPTION
Pushes of images to the integrated registry sometimes fail
because credentials are not mounted correctly, or occasionally other
reason. This change adds a retry of the build if it fails after
reaching the push stage.