### PR TITLE
Skip delete command for shared cluster in start.sh

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -332,6 +332,10 @@ else
     # app completed, we take the cluster with us, as long as our repl count is 0 or 1 (if it's more
     # then someone scaled the driver and we have to leave the cluster anyway).
     trap exit_flag TERM INT
-    delete_ephemeral completed
+    if [ "$ephemeral" == "<shared>" ]; then
+	echo "cluster is not ephemeral, not deleting '$OSHINKO_CLUSTER_NAME'"
+    else
+        delete_ephemeral completed
+    fi
 fi
 app_exit

--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -333,7 +333,8 @@ else
     # then someone scaled the driver and we have to leave the cluster anyway).
     trap exit_flag TERM INT
     if [ "$ephemeral" == "<shared>" ]; then
-	echo "cluster is not ephemeral, not deleting '$OSHINKO_CLUSTER_NAME'"
+	echo "cluster is not ephemeral"
+	echo "cluster not deleted '$OSHINKO_CLUSTER_NAME'"
     else
         delete_ephemeral completed
     fi


### PR DESCRIPTION
Deletion of a shared cluster from start.sh will fail with an
error message and leave the cluster. Since start.sh knows if
the cluster is ephemeral or not, just skip the delete command
instead.