### PR TITLE
Preserve output as much as possible in delete shared case

### DIFF
--- a/common/utils/start.sh
+++ b/common/utils/start.sh
@@ -28,9 +28,14 @@ function get_deployment {
 function delete_ephemeral {
     local appstatus=$1
     local line
-    echo "Deleting cluster $OSHINKO_CLUSTER_NAME"
-    line=$($CLI delete_eph $OSHINKO_CLUSTER_NAME --app=$POD_NAME --app-status=$1 $CLI_ARGS 2>&1)
-    echo $line
+    echo "Deleting cluster '$OSHINKO_CLUSTER_NAME'"
+    if [ "$ephemeral" == "<shared>" ]; then
+	echo "cluster is not ephemeral"
+	echo "cluster not deleted '$OSHINKO_CLUSTER_NAME'"
+    else
+        line=$($CLI delete_eph $OSHINKO_CLUSTER_NAME --app=$POD_NAME --app-status=$1 $CLI_ARGS 2>&1)
+        echo $line
+    fi
 }
 
 function handle_term {
@@ -332,11 +337,6 @@ else
     # app completed, we take the cluster with us, as long as our repl count is 0 or 1 (if it's more
     # then someone scaled the driver and we have to leave the cluster anyway).
     trap exit_flag TERM INT
-    if [ "$ephemeral" == "<shared>" ]; then
-	echo "cluster is not ephemeral"
-	echo "cluster not deleted '$OSHINKO_CLUSTER_NAME'"
-    else
-        delete_ephemeral completed
-    fi
+    delete_ephemeral completed
 fi
 app_exit

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -221,14 +221,12 @@ function run_job() {
 function cleanup_app() {
 
     # We may have code shared by build templates and app templates
-    # that calls cleanup_app, and the build tempaltes may not have dcs ...
+    # that calls cleanup_app, and the build templates may not have dcs ...
     set +e
-    oc scale dc/"$APP_NAME" --replicas=0
-    set -e
+#    oc scale dc/"$APP_NAME" --replicas=0
     os::cmd::try_until_text 'oc get pods -l deploymentconfig="$APP_NAME"' 'No resources found' $((5*minute))
-    set +e
     oc delete dc/"$APP_NAME"
-    os::cmd::try_until_failure 'oc logs dc/$APP_NAME' $((5*minute))
+    os::cmd::try_until_failure 'oc logs dc/$APP_NAME' $((10*minute))
     set -e
 #    if [ "$#" -eq 1 ]; then
 #        #os::cmd::try_until_failure 'oc get dc "$MASTER_DC"' $((5*minute))

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -224,7 +224,7 @@ function cleanup_app() {
     # that calls cleanup_app, and the build templates may not have dcs ...
     set +e
 #    oc scale dc/"$APP_NAME" --replicas=0
-    os::cmd::try_until_text 'oc get pods -l deploymentconfig="$APP_NAME"' 'No resources found' $((5*minute))
+#    os::cmd::try_until_text 'oc get pods -l deploymentconfig="$APP_NAME"' 'No resources found' $((5*minute))
     oc delete dc/"$APP_NAME"
     os::cmd::try_until_failure 'oc logs dc/$APP_NAME' $((10*minute))
     set -e


### PR DESCRIPTION
This is a further refinement of recent changes to prevent an
error from being reported when an s2i application ends which
is using a shared cluster. This change prevents an error from
being reported but keeps the output as close as possible to
previous versions.