### PR TITLE
homogenize templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,20 @@
+# OpenShift Templates
+
+This directory contains various OpenShift templates to enable using the S2I
+images created from this repository.
+
+## Files
+
+The files are named with the language they are designed to be used with and
+the objects created by the template.
+
+* `javabuild.json` - Java based S2I for a BuildConfig
+* `javabuilddc.json` - Java based S2I for a BuildConfig and DeploymentConfig
+* `javadc.json` - Java based for DeploymentConfig
+* `pythonbuild.json` - Python based S2I for a BuildConfig
+* `pythonbuilddc.json` - Python based S2I for a BuildConfig and DeploymentConfig
+* `pythondc.json` - Python based for a DeploymentConfig
+* `scalabuild.json` - Scala based S2I for a BuildConfig
+* `scalabuilddc.json` - Scala based S2I for a BuildConfig and DeploymentConfig
+* `scaladc.json` - Scala based for a DeploymentConfig
+* `sparkjob.json` - All language Job

--- a/templates/javabuild.json
+++ b/templates/javabuild.json
@@ -4,7 +4,7 @@
    "metadata": {
       "name": "oshinko-java-spark-build",
       "annotations": {
-         "description": "Create a buildconfig and imagestream using STI and java spark source hosted in git"
+         "description": "Create a buildconfig and imagestream using source-to-image and Java Spark source files hosted in git"
       }
    },
    "labels": {
@@ -13,19 +13,16 @@
    },
    "parameters": [
       {
-         "description": "The name to to use for the buildconfig and imagestream",
+         "description": "The name to to use for the buildconfig and imagestream objects",
          "name": "APPLICATION_NAME",
          "generate": "expression",
          "from": "java-spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
-         "name": "APP_FILE"
-      },
-      {
          "description": "Git source URI for application",
-         "name": "GIT_URI"
+         "name": "GIT_URI",
+         "required": true
       },
       {
          "description": "Git branch/tag reference",
@@ -35,9 +32,28 @@
       {
          "description": "Git sub-directory path",
          "name": "CONTEXT_DIR"
+      },
+      {
+         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
+         "name": "APP_FILE"
       }
    ],
    "objects": [
+      {
+         "kind": "ImageStream",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}"
+         },
+         "spec": {
+            "dockerImageRepository": "${APPLICATION_NAME}",
+            "tags": [
+               {
+                  "name": "latest"
+               }
+            ]
+         }
+      },
       {
          "kind": "BuildConfig",
          "apiVersion": "v1",
@@ -96,21 +112,6 @@
                   "name": "${APPLICATION_NAME}:latest"
                }
             }
-         }
-      },
-      {
-         "kind": "ImageStream",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "dockerImageRepository": "${APPLICATION_NAME}",
-            "tags": [
-               {
-                  "name": "latest"
-               }
-            ]
          }
       }
    ]

--- a/templates/javabuilddc.json
+++ b/templates/javabuilddc.json
@@ -4,7 +4,8 @@
    "metadata": {
       "name": "oshinko-java-spark-build-dc",
       "annotations": {
-         "description": "Create a buildconfig, imagestream and deploymentconfig using STI and java spark source hosted in git"
+         "openshift.io/display-name": "Apache Spark Java",
+         "description": "Create a buildconfig, imagestream and deploymentconfig using source-to-image and Java Spark source files hosted in git"
       }
    },
    "labels": {
@@ -13,46 +14,11 @@
    },
    "parameters": [
       {
-         "description": "The name to use for the buildconfig, imagestream and deployment components",
+         "description": "The name to use for the buildconfig, imagestream and deployment objects",
          "name": "APPLICATION_NAME",
          "generate": "expression",
          "from": "java-spark-[a-z0-9]{4}",
          "required": true
-      },
-      {
-         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
-         "name": "OSHINKO_CLUSTER_NAME"
-      },
-      {
-         "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
-         "name": "OSHINKO_NAMED_CONFIG"
-      },
-      {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
-      },
-      {
-         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
-         "name": "OSHINKO_DEL_CLUSTER",
-         "value": "true",
-         "required": true
-      },
-      {
-         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
-         "name": "APP_FILE"
-      },
-      {
-         "description": "Command line arguments to pass to the spark application",
-         "name": "APP_ARGS"
-      },
-      {
-         "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS",
-         "required": true
-      },
-      {
-          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
-         "name": "SPARK_OPTIONS"
       },
       {
          "description": "Git source URI for application",
@@ -66,6 +32,40 @@
       {
          "description": "Git sub-directory path",
          "name": "CONTEXT_DIR"
+      },
+      {
+         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
+         "name": "APP_FILE"
+      },
+      {
+         "description": "Command line arguments to pass to the Spark application",
+         "name": "APP_ARGS"
+      },
+      {
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
+          "description": "List of additional Spark options to pass to spark-submit (for example --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+         "name": "SPARK_OPTIONS"
+      },
+      {
+         "description": "The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
+      },
+      {
+         "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
+         "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
+         "description": "The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.",
+         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
+      },
+      {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "true",
+         "required": true
       },
       {
          "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
@@ -207,8 +207,8 @@
                            },
                            {
                               "name": "SPARK_OPTIONS",
-                               "value": "${SPARK_OPTIONS}"
-			   },
+                              "value": "${SPARK_OPTIONS}"
+                           },
                            {
                               "name": "APP_MAIN_CLASS",
                               "value": "${APP_MAIN_CLASS}"
@@ -217,7 +217,8 @@
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"
                            },
-                           {  "name": "APP_EXIT",
+                           {
+                              "name": "APP_EXIT",
                               "value": "${APP_EXIT}"
                            },
                            {
@@ -241,7 +242,7 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
+                        "imagePullPolicy": "IfNotPresent",
                         "volumeMounts": [
                            {
                               "mountPath": "/etc/podinfo",
@@ -271,6 +272,29 @@
                   "dnsPolicy": "ClusterFirst"
                }
             }
+         }
+      },
+      {
+         "kind": "Service",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}",
+            "labels": {
+                "app": "${APPLICATION_NAME}"
+            }
+         },
+         "spec": {
+             "ports": [
+                 {
+                     "name": "8080-tcp",
+                     "port": 8080,
+                     "protocol": "TCP",
+                     "targetPort": 8080
+                 }
+             ],
+             "selector": {
+                 "deploymentConfig": "${APPLICATION_NAME}"
+             }
          }
       }
    ]

--- a/templates/javadc.json
+++ b/templates/javadc.json
@@ -2,30 +2,42 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-pyspark-dc",
+      "name": "oshinko-java-spark-dc",
       "annotations": {
-         "description": "Create a deploymentconfig using an existing pyspark imagestream"
+         "description": "Create a deploymentconfig using an existing Java Spark image"
       }
    },
    "labels": {
-      "application": "oshinko-pyspark",
-      "createdBy": "template-oshinko-pyspark-dc"
+      "application": "oshinko-java-spark",
+      "createdBy": "template-oshinko-java-spark-dc"
    },
    "parameters": [
       {
-         "description": "The name to use for the deployment components",
+         "description": "The name to use for the deployment objects",
          "name": "APPLICATION_NAME",
          "generate": "expression",
-         "from": "pyspark-[a-z0-9]{4}",
+         "from": "java-spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "The name of the pyspark imagestream to use (the 'latest' tag will be used')",
+         "description": "The name of the Java Spark imagestream to use (the 'latest' tag will be used')",
          "name": "IMAGE",
          "required": true
       },
       {
-         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "description": "Command line arguments to pass to the Spark application",
+         "name": "APP_ARGS"
+      },
+      {
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
+         "description": "List of additional Spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+         "name": "SPARK_OPTIONS"
+      },
+      {
+         "description": "The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
@@ -33,7 +45,7 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-        "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
+        "description": "The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.",
         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
@@ -41,14 +53,6 @@
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
          "required": true
-      },
-      {
-         "description": "Command line arguments to pass to the spark application",
-         "name": "APP_ARGS"
-      },
-      {
-         "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
-         "name": "SPARK_OPTIONS"
       },
       {
          "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
@@ -62,7 +66,10 @@
          "kind": "DeploymentConfig",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}"
+            "name": "${APPLICATION_NAME}",
+            "labels": {
+               "deploymentConfig": "${APPLICATION_NAME}"
+            }
          },
          "spec": {
             "strategy": {
@@ -88,12 +95,12 @@
             ],
             "replicas": 1,
             "selector": {
-               "deploymentconfig": "${APPLICATION_NAME}"
+               "deploymentConfig": "${APPLICATION_NAME}"
             },
             "template": {
                "metadata": {
                   "labels": {
-                     "deploymentconfig": "${APPLICATION_NAME}"
+                     "deploymentConfig": "${APPLICATION_NAME}"
                   }
                },
                "spec": {
@@ -113,6 +120,10 @@
                            {
                               "name": "SPARK_OPTIONS",
                               "value": "${SPARK_OPTIONS}"
+                           },
+                           {
+                              "name": "APP_MAIN_CLASS",
+                              "value": "${APP_MAIN_CLASS}"
                            },
                            {
                              "name": "OSHINKO_DEL_CLUSTER",
@@ -143,7 +154,7 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
+                        "imagePullPolicy": "IfNotPresent",
                         "volumeMounts": [
                            {
                               "mountPath": "/etc/podinfo",
@@ -174,6 +185,30 @@
                }
             }
          }
+      },
+      {
+         "kind": "Service",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}",
+            "labels": {
+                "app": "${APPLICATION_NAME}"
+            }
+         },
+         "spec": {
+             "ports": [
+                 {
+                     "name": "8080-tcp",
+                     "port": 8080,
+                     "protocol": "TCP",
+                     "targetPort": 8080
+                 }
+             ],
+             "selector": {
+                 "deploymentConfig": "${APPLICATION_NAME}"
+             }
+         }
       }
    ]
 }
+

--- a/templates/pythonbuild.json
+++ b/templates/pythonbuild.json
@@ -2,21 +2,21 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-pyspark-build",
+      "name": "oshinko-python-build",
       "annotations": {
-         "description": "Create a buildconfig and imagestream using STI and pyspark source hosted in git"
+         "description": "Create a buildconfig and imagestream using source-to-image and Python Spark source files hosted in git"
       }
    },
    "labels": {
-      "application": "oshinko-pyspark",
-      "createdBy": "template-oshinko-pyspark-build"
+      "application": "oshinko-python-spark",
+      "createdBy": "template-oshinko-python-spark-build"
    },
    "parameters": [
       {
          "description": "The name to to use for the buildconfig and imagestream",
          "name": "APPLICATION_NAME",
          "generate": "expression",
-         "from": "pyspark-[a-z0-9]{4}",
+         "from": "python-spark-[a-z0-9]{4}",
          "required": true
       },
       {

--- a/templates/pythonbuilddc.json
+++ b/templates/pythonbuilddc.json
@@ -2,56 +2,52 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-scala-spark-build-dc",
+      "name": "oshinko-python-build-dc",
       "annotations": {
-         "openshift.io/display-name": "Apache Spark Scala",
-         "description": "Create a buildconfig, imagestream and deploymentconfig using source-to-image and Scala Spark source files hosted in git"
+         "openshift.io/display-name": "Apache Spark Python",
+         "description": "Create a buildconfig, imagestream and deploymentconfig using source-to-image and Python Spark source files hosted in git"
       }
    },
    "labels": {
-      "application": "oshinko-scala-spark",
-      "createdBy": "template-oshinko-scala-spark-build-dc"
+      "application": "oshinko-python-spark",
+      "createdBy": "template-oshinko-python-spark-build-dc"
    },
    "parameters": [
       {
-         "description": "The name to use for the buildconfig, imagestream and deployment objects",
+         "description": "The name to use for the buildconfig, imagestream and deployment components",
          "name": "APPLICATION_NAME",
          "generate": "expression",
-         "from": "scala-spark-[a-z0-9]{4}",
+         "from": "python-spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "Git source URI for application",
+         "displayName": "Git Repository URL",
+         "description": "The URL of the repository with your application source code",
          "name": "GIT_URI"
       },
       {
-         "description": "Git branch/tag reference",
-         "name": "GIT_REF",
-         "value": "master"
+         "displayName": "Git Reference",
+         "description": "Optional branch, tag or commit",
+         "name": "GIT_REF"
       },
       {
          "description": "Git sub-directory path",
          "name": "CONTEXT_DIR"
       },
       {
-         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
+         "description": "The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.",
          "name": "APP_FILE"
       },
       {
-         "description": "Command line arguments to pass to the spark application",
+         "description": "Command line arguments to pass to the Spark application",
          "name": "APP_ARGS"
       },
       {
-         "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS",
-         "required": true
-      },
-      {
-          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+          "description": "List of additional Spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       },
       {
-         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "description": "The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
@@ -59,7 +55,7 @@
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
+         "description": "The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.",
          "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
@@ -67,14 +63,6 @@
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
          "required": true
-      },
-      {
-         "description": "Arguments to use when calling sbt, replacing the default `package`",
-         "name": "SBT_ARGS"
-      },
-      {
-         "description": "Additional sbt arguments, useful for adding task arguments to sbt like `publish makePom`",
-         "name": "SBT_ARGS_APPEND"
       },
       {
          "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
@@ -140,21 +128,13 @@
                "sourceStrategy": {
                   "from": {
                      "kind": "DockerImage",
-                     "name": "radanalyticsio/radanalytics-scala-spark"
+                     "name": "radanalyticsio/radanalytics-pyspark"
                   },
                   "forcePull": true,
                   "env": [
                      {
                         "name": "APP_FILE",
                         "value": "${APP_FILE}"
-                     },
-                     {
-                         "name": "SBT_ARGS",
-                         "value": "${SBT_ARGS}"
-                     },
-                     {
-                         "name": "SBT_ARGS_APPEND",
-                         "value": "${SBT_ARGS_APPEND}"
                      }
                   ]
                }
@@ -171,10 +151,7 @@
          "kind": "DeploymentConfig",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-               "deploymentConfig": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
             "strategy": {
@@ -200,12 +177,12 @@
             ],
             "replicas": 1,
             "selector": {
-               "deploymentConfig": "${APPLICATION_NAME}"
+               "deploymentconfig": "${APPLICATION_NAME}"
             },
             "template": {
                "metadata": {
                   "labels": {
-                     "deploymentConfig": "${APPLICATION_NAME}"
+                     "deploymentconfig": "${APPLICATION_NAME}"
                   }
                },
                "spec": {
@@ -225,10 +202,6 @@
                            {
                               "name": "SPARK_OPTIONS",
                                "value": "${SPARK_OPTIONS}"
-                           },
-                           {
-                              "name": "APP_MAIN_CLASS",
-                              "value": "${APP_MAIN_CLASS}"
                            },
                            {
                              "name": "OSHINKO_DEL_CLUSTER",
@@ -254,7 +227,7 @@
                                          "fieldPath": "metadata.name"
                                       }
                                 }
-                           }
+                            }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",

--- a/templates/pythondc.json
+++ b/templates/pythondc.json
@@ -2,66 +2,53 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-pyspark-build-dc",
+      "name": "oshinko-python-dc",
       "annotations": {
-         "openshift.io/display-name": "PySpark",
-         "description": "Create a buildconfig, imagestream and deploymentconfig using STI and pyspark source hosted in git"
+         "description": "Create a deploymentconfig using an existing Python Spark image"
       }
    },
    "labels": {
-      "application": "oshinko-pyspark",
-      "createdBy": "template-oshinko-pyspark-build-dc"
+      "application": "oshinko-python-spark",
+      "createdBy": "template-oshinko-python-spark-dc"
    },
    "parameters": [
       {
-         "displayName": "Git Repository URL",
-         "description": "The URL of the repository with your application source code",
-         "name": "GIT_URI"
-      },
-      {
-         "displayName": "Git Reference",
-         "description": "Optional branch, tag or commit",
-         "name": "GIT_REF"
-      },
-      {
-         "description": "Git sub-directory path",
-         "name": "CONTEXT_DIR"
-      },
-      {
-         "description": "The name to use for the buildconfig, imagestream and deployment components",
+         "description": "The name to use for the deployment components",
          "name": "APPLICATION_NAME",
          "generate": "expression",
-         "from": "pyspark-[a-z0-9]{4}"
-      },
-      {
-         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
-         "name": "OSHINKO_CLUSTER_NAME"
-      },
-      {
-         "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
-         "name": "OSHINKO_NAMED_CONFIG"
-      },
-      {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
-      },
-      {
-         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
-         "name": "OSHINKO_DEL_CLUSTER",
-         "value": "true",
+         "from": "python-spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "The name of the main py file to run. If this is not specified and there is a single py file at top level of the git respository, that file will be chosen.",
-         "name": "APP_FILE"
+         "description": "The name of the pyspark imagestream to use (the 'latest' tag will be used')",
+         "name": "IMAGE",
+         "required": true
       },
       {
          "description": "Command line arguments to pass to the spark application",
          "name": "APP_ARGS"
       },
       {
-          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+         "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
+      },
+      {
+         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "name": "OSHINKO_CLUSTER_NAME"
+      },
+      {
+	  "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default.",
+         "name": "OSHINKO_NAMED_CONFIG"
+      },
+      {
+        "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
+        "name": "OSHINKO_SPARK_DRIVER_CONFIG"
+      },
+      {
+         "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
+         "name": "OSHINKO_DEL_CLUSTER",
+         "value": "true",
+         "required": true
       },
       {
          "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
@@ -71,81 +58,6 @@
       }
    ],
    "objects": [
-      {
-         "kind": "ImageStream",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "dockerImageRepository": "${APPLICATION_NAME}",
-            "tags": [
-               {
-                  "name": "latest"
-               }
-            ]
-         }
-      },
-      {
-         "kind": "BuildConfig",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "triggers": [
-               {
-                  "type": "ImageChange",
-                  "imageChange": {}
-               },
-               {
-                  "type": "ConfigChange"
-               },
-               {
-                  "type": "GitHub",
-                  "github": {
-                      "secret": "${APPLICATION_NAME}"
-                  }
-               },
-               {
-                  "type": "Generic",
-                  "generic": {
-                      "secret": "${APPLICATION_NAME}"
-                  }
-               }
-            ],
-            "source": {
-               "type": "Git",
-               "git": {
-                  "uri": "${GIT_URI}",
-                  "ref": "${GIT_REF}"
-               },
-               "contextDir": "${CONTEXT_DIR}"
-            },
-            "strategy": {
-               "type": "Source",
-               "sourceStrategy": {
-                  "from": {
-                     "kind": "DockerImage",
-                     "name": "radanalyticsio/radanalytics-pyspark"
-                  },
-                  "forcePull": true,
-                  "env": [
-                     {
-                        "name": "APP_FILE",
-                        "value": "${APP_FILE}"
-                     }
-                  ]
-               }
-            },
-            "output": {
-               "to": {
-                  "kind": "ImageStreamTag",
-                  "name": "${APPLICATION_NAME}:latest"
-               }
-            }
-         }
-      },
       {
          "kind": "DeploymentConfig",
          "apiVersion": "v1",
@@ -166,7 +78,7 @@
                      ],
                      "from": {
                         "kind": "ImageStreamTag",
-                        "name": "${APPLICATION_NAME}:latest"
+                        "name": "${IMAGE}:latest"
                      }
                   }
                },
@@ -188,7 +100,7 @@
                   "containers": [
                      {
                         "name": "${APPLICATION_NAME}",
-                        "image": "${APPLICATION_NAME}",
+                        "image": "${IMAGE}",
                         "env": [
                            {
                               "name": "OSHINKO_CLUSTER_NAME",
@@ -200,13 +112,14 @@
                            },
                            {
                               "name": "SPARK_OPTIONS",
-                               "value": "${SPARK_OPTIONS}"
+                              "value": "${SPARK_OPTIONS}"
                            },
                            {
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"
                            },
-                           {  "name": "APP_EXIT",
+                           {
+                              "name": "APP_EXIT",
                               "value": "${APP_EXIT}"
                            },
                            {
@@ -226,7 +139,7 @@
                                          "fieldPath": "metadata.name"
                                       }
                                 }
-                            }
+                           }
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
@@ -260,6 +173,29 @@
                   "dnsPolicy": "ClusterFirst"
                }
             }
+         }
+      },
+      {
+         "kind": "Service",
+         "apiVersion": "v1",
+         "metadata": {
+            "name": "${APPLICATION_NAME}",
+            "labels": {
+                "app": "${APPLICATION_NAME}"
+            }
+         },
+         "spec": {
+             "ports": [
+                 {
+                     "name": "8080-tcp",
+                     "port": 8080,
+                     "protocol": "TCP",
+                     "targetPort": 8080
+                 }
+             ],
+             "selector": {
+                 "deploymentConfig": "${APPLICATION_NAME}"
+             }
          }
       }
    ]

--- a/templates/scalabuild.json
+++ b/templates/scalabuild.json
@@ -4,7 +4,7 @@
    "metadata": {
       "name": "oshinko-scala-spark-build",
       "annotations": {
-         "description": "Create a buildconfig and imagestream using STI and Scala Spark source hosted in git"
+         "description": "Create a buildconfig and imagestream using source-to-image and Scala Spark source files hosted in git"
       }
    },
    "labels": {
@@ -13,15 +13,11 @@
    },
    "parameters": [
       {
-         "description": "The name to to use for the buildconfig and imagestream",
+         "description": "The name to to use for the buildconfig and imagestream objects",
          "name": "APPLICATION_NAME",
          "generate": "expression",
          "from": "scala-spark-[a-z0-9]{4}",
          "required": true
-      },
-      {
-         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
-         "name": "APP_FILE"
       },
       {
          "description": "Git source URI for application",
@@ -35,6 +31,10 @@
       {
          "description": "Git sub-directory path",
          "name": "CONTEXT_DIR"
+      },
+      {
+         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
+         "name": "APP_FILE"
       },
       {
          "description": "Arguments to use when calling sbt, replacing the default `package`",

--- a/templates/scaladc.json
+++ b/templates/scaladc.json
@@ -2,79 +2,57 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-scala-spark-build-dc",
+      "name": "oshinko-scala-spark-dc",
       "annotations": {
-         "openshift.io/display-name": "Apache Spark Scala",
-         "description": "Create a buildconfig, imagestream and deploymentconfig using source-to-image and Scala Spark source files hosted in git"
+         "description": "Create a deploymentconfig using an existing Scala Spark image"
       }
    },
    "labels": {
       "application": "oshinko-scala-spark",
-      "createdBy": "template-oshinko-scala-spark-build-dc"
+      "createdBy": "template-oshinko-scala-spark-dc"
    },
    "parameters": [
       {
-         "description": "The name to use for the buildconfig, imagestream and deployment objects",
+         "description": "The name to use for the deployment objects",
          "name": "APPLICATION_NAME",
          "generate": "expression",
          "from": "scala-spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "Git source URI for application",
-         "name": "GIT_URI"
+         "description": "The name of the Scala Spark imagestream to use (the 'latest' tag will be used')",
+         "name": "IMAGE",
+         "required": true
       },
       {
-         "description": "Git branch/tag reference",
-         "name": "GIT_REF",
-         "value": "master"
-      },
-      {
-         "description": "Git sub-directory path",
-         "name": "CONTEXT_DIR"
-      },
-      {
-         "description": "The name of the main JAR file. If this is not specified and there is a single JAR produced by the build, that JAR will be chosen.",
-         "name": "APP_FILE"
-      },
-      {
-         "description": "Command line arguments to pass to the spark application",
+         "description": "Command line arguments to pass to the Spark application",
          "name": "APP_ARGS"
       },
       {
          "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS",
-         "required": true
+         "name": "APP_MAIN_CLASS"
       },
       {
-          "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+         "description": "List of additional Spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
          "name": "SPARK_OPTIONS"
       },
       {
-         "description": "The name of the spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
+         "description": "The name of the Spark cluster to run against. The cluster will be created if it does not exist, and a random cluster name will be chosen if this value is left blank.",
          "name": "OSHINKO_CLUSTER_NAME"
       },
       {
-         "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default'.",
+	  "description": "The name of a stored cluster configuration to use if a cluster is created, default is 'default.",
          "name": "OSHINKO_NAMED_CONFIG"
       },
       {
-         "description": "The name of a configmap to use for the spark configuration of the driver. If this configmap is empty the default spark configuration will be used.",
-         "name": "OSHINKO_SPARK_DRIVER_CONFIG"
+        "description": "The name of a configmap to use for the Spark configuration of the driver. If this configmap is empty the default Spark configuration will be used.",
+        "name": "OSHINKO_SPARK_DRIVER_CONFIG"
       },
       {
          "description": "If a cluster is created on-demand, delete the cluster when the application finishes if this option is set to 'true'",
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
          "required": true
-      },
-      {
-         "description": "Arguments to use when calling sbt, replacing the default `package`",
-         "name": "SBT_ARGS"
-      },
-      {
-         "description": "Additional sbt arguments, useful for adding task arguments to sbt like `publish makePom`",
-         "name": "SBT_ARGS_APPEND"
       },
       {
          "description": "Setting this value to 'false' prevents the application from being re-deployed if/when it completes",
@@ -84,89 +62,6 @@
       }
    ],
    "objects": [
-      {
-         "kind": "ImageStream",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "dockerImageRepository": "${APPLICATION_NAME}",
-            "tags": [
-               {
-                  "name": "latest"
-               }
-            ]
-         }
-      },
-      {
-         "kind": "BuildConfig",
-         "apiVersion": "v1",
-         "metadata": {
-            "name": "${APPLICATION_NAME}"
-         },
-         "spec": {
-            "triggers": [
-               {
-                  "type": "ImageChange",
-                  "imageChange": {}
-               },
-               {
-                  "type": "ConfigChange"
-               },
-               {
-                  "type": "GitHub",
-                  "github": {
-                      "secret": "${APPLICATION_NAME}"
-                  }
-               },
-               {
-                  "type": "Generic",
-                  "generic": {
-                      "secret": "${APPLICATION_NAME}"
-                  }
-               }
-            ],
-            "source": {
-               "type": "Git",
-               "git": {
-                  "uri": "${GIT_URI}",
-                  "ref": "${GIT_REF}"
-               },
-               "contextDir": "${CONTEXT_DIR}"
-            },
-            "strategy": {
-               "type": "Source",
-               "sourceStrategy": {
-                  "from": {
-                     "kind": "DockerImage",
-                     "name": "radanalyticsio/radanalytics-scala-spark"
-                  },
-                  "forcePull": true,
-                  "env": [
-                     {
-                        "name": "APP_FILE",
-                        "value": "${APP_FILE}"
-                     },
-                     {
-                         "name": "SBT_ARGS",
-                         "value": "${SBT_ARGS}"
-                     },
-                     {
-                         "name": "SBT_ARGS_APPEND",
-                         "value": "${SBT_ARGS_APPEND}"
-                     }
-                  ]
-               }
-            },
-            "output": {
-               "to": {
-                  "kind": "ImageStreamTag",
-                  "name": "${APPLICATION_NAME}:latest"
-               }
-            }
-         }
-      },
       {
          "kind": "DeploymentConfig",
          "apiVersion": "v1",
@@ -190,7 +85,7 @@
                      ],
                      "from": {
                         "kind": "ImageStreamTag",
-                        "name": "${APPLICATION_NAME}:latest"
+                        "name": "${IMAGE}:latest"
                      }
                   }
                },
@@ -212,7 +107,7 @@
                   "containers": [
                      {
                         "name": "${APPLICATION_NAME}",
-                        "image": "${APPLICATION_NAME}",
+                        "image": "${IMAGE}",
                         "env": [
                            {
                               "name": "OSHINKO_CLUSTER_NAME",
@@ -224,7 +119,7 @@
                            },
                            {
                               "name": "SPARK_OPTIONS",
-                               "value": "${SPARK_OPTIONS}"
+                              "value": "${SPARK_OPTIONS}"
                            },
                            {
                               "name": "APP_MAIN_CLASS",
@@ -234,7 +129,8 @@
                              "name": "OSHINKO_DEL_CLUSTER",
                              "value": "${OSHINKO_DEL_CLUSTER}"
                            },
-                           {  "name": "APP_EXIT",
+                           {
+                              "name": "APP_EXIT",
                               "value": "${APP_EXIT}"
                            },
                            {
@@ -258,7 +154,7 @@
                         ],
                         "resources": {},
                         "terminationMessagePath": "/dev/termination-log",
-                        "imagePullPolicy": "Always",
+                        "imagePullPolicy": "IfNotPresent",
                         "volumeMounts": [
                            {
                               "mountPath": "/etc/podinfo",
@@ -315,3 +211,4 @@
       }
    ]
 }
+

--- a/templates/sparkjob.json
+++ b/templates/sparkjob.json
@@ -2,27 +2,39 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-pyspark-job",
+      "name": "oshinko-spark-job",
       "annotations": {
-         "description": "Create a job using an existing pyspark imagestream"
+         "description": "Create a job using an existing Spark image"
       }
    },
    "labels": {
-      "application": "oshinko-pyspark",
-      "createdBy": "template-oshinko-pyspark-job"
+      "application": "oshinko-spark",
+      "createdBy": "template-oshinko-spark-job"
    },
    "parameters": [
       {
          "description": "The name to use for the job",
          "name": "APPLICATION_NAME",
          "generate": "expression",
-         "from": "pyspark-[a-z0-9]{4}",
+         "from": "spark-[a-z0-9]{4}",
          "required": true
       },
       {
-         "description": "The docker pull specification of the image to run",
+         "description": "The Docker pull specification of the image to run",
          "name": "IMAGE",
          "required": true
+      },
+      {
+         "description": "Command line arguments to pass to the application",
+         "name": "APP_ARGS"
+      },
+      {
+         "description": "Application main class for jar-based applications",
+         "name": "APP_MAIN_CLASS"
+      },
+      {
+         "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
+         "name": "SPARK_OPTIONS"
       },
       {
         "description": "The desired number of successful completions",
@@ -48,18 +60,6 @@
          "name": "OSHINKO_DEL_CLUSTER",
          "value": "true",
          "required": true
-      },
-      {
-         "description": "Command line arguments to pass to the pyspark application",
-         "name": "APP_ARGS"
-      },
-      {
-         "description": "Application main class for jar-based applications",
-         "name": "APP_MAIN_CLASS"
-      },
-      {
-         "description": "List of additional spark options to pass to spark-submit (for exmaple --conf property=value --conf property=value). Note, --master and --class are set by the launcher and should not be set here",
-         "name": "SPARK_OPTIONS"
       }
    ],
    "objects": [
@@ -157,3 +157,4 @@
 
    ]
 }
+

--- a/test/e2e/common
+++ b/test/e2e/common
@@ -170,7 +170,7 @@ function run_app() {
 	return 1
     fi
     if [ "$1" != true ]; then
-        os::cmd::expect_success 'oc new-app --file="$PYSPARK_DIR"/pysparkdc.json -p IMAGE=play -p APPLICATION_NAME="$APP_NAME" -p APP_EXIT="$DO_EXIT" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" -p OSHINKO_NAMED_CONFIG=clusterconfig -p OSHINKO_SPARK_DRIVER_CONFIG="$DRIVER_CONFIG" -e TEST_MODE="$DO_TEST"'
+        os::cmd::expect_success 'oc new-app --file="$PYSPARK_DIR"/pythondc.json -p IMAGE=play -p APPLICATION_NAME="$APP_NAME" -p APP_EXIT="$DO_EXIT" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" -p OSHINKO_NAMED_CONFIG=clusterconfig -p OSHINKO_SPARK_DRIVER_CONFIG="$DRIVER_CONFIG" -e TEST_MODE="$DO_TEST"'
 
         os::cmd::try_until_text 'oc logs dc/$APP_NAME' 'Using.*cluster' $((5*minute))
         GEN_CLUSTER_NAME=$(oc logs dc/$APP_NAME | sed -rn "s@Using (shared|ephemeral) cluster (.*$)@\2@p")
@@ -180,7 +180,7 @@ function run_app() {
 	if [ "$GEN_CLUSTER_NAME" == "" ]; then
             GEN_CLUSTER_NAME=cl-$SUFFIX
 	fi
-        os::cmd::expect_success 'oc new-app --file="$PYSPARK_DIR"/pysparkdc.json -p IMAGE=play -p OSHINKO_CLUSTER_NAME="$GEN_CLUSTER_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_EXIT="$DO_EXIT" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" -p OSHINKO_NAMED_CONFIG=clusterconfig -p OSHINKO_SPARK_DRIVER_CONFIG="$DRIVER_CONFIG" -e TEST_MODE="$DO_TEST"'
+        os::cmd::expect_success 'oc new-app --file="$PYSPARK_DIR"/pythondc.json -p IMAGE=play -p OSHINKO_CLUSTER_NAME="$GEN_CLUSTER_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_EXIT="$DO_EXIT" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" -p OSHINKO_NAMED_CONFIG=clusterconfig -p OSHINKO_SPARK_DRIVER_CONFIG="$DRIVER_CONFIG" -e TEST_MODE="$DO_TEST"'
     fi 
     echo Using cluster name $GEN_CLUSTER_NAME
     MASTER_DC=$GEN_CLUSTER_NAME-m
@@ -201,7 +201,7 @@ function run_job() {
 	return 1
     fi
     if [ "$1" != true ]; then
-        os::cmd::expect_success 'oc process -f "$PYSPARK_DIR"/pysparkjob.json -p IMAGE="$IMAGE_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" | oc create -f -'
+        os::cmd::expect_success 'oc process -f "$PYSPARK_DIR"/sparkjob.json -p IMAGE="$IMAGE_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" | oc create -f -'
         # Well, we have no easy way of figuring out what the clustername is here since we're not using a dc but if we figure out the pod name we can grep the log
         # Use the os::cmd_try_until_xxx functions to gate
         os::cmd::try_until_success 'oc get pod -l job-name="$APP_NAME"'
@@ -213,7 +213,7 @@ function run_job() {
 	if [ "$GEN_CLUSTER_NAME" == "" ]; then
             GEN_CLUSTER_NAME=cl-$SUFFIX
 	fi
-        os::cmd::expect_success 'oc process -f "$PYSPARK_DIR"/pysparkjob.json -p IMAGE="$IMAGE_NAME" -p OSHINKO_CLUSTER_NAME="$GEN_CLUSTER_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" | oc create -f -'
+        os::cmd::expect_success 'oc process -f "$PYSPARK_DIR"/sparkjob.json -p IMAGE="$IMAGE_NAME" -p OSHINKO_CLUSTER_NAME="$GEN_CLUSTER_NAME" -p APPLICATION_NAME="$APP_NAME" -p APP_ARGS="$SLEEP" -p OSHINKO_DEL_CLUSTER="$DEL_CLUSTER" | oc create -f -'
     fi
     echo Using cluster name $GEN_CLUSTER_NAME
     MASTER_DC=$GEN_CLUSTER_NAME-m

--- a/test/e2e/templates/pyspark/build/pysparkbuild.sh
+++ b/test/e2e/templates/pyspark/build/pysparkbuild.sh
@@ -11,9 +11,9 @@ source $SCRIPT_DIR/../../builddc
 source $SCRIPT_DIR/../../buildonly
 
 RESOURCE_DIR=$TEST_DIR/resources
-cp $PYSPARK_DIR/pysparkbuild.json $RESOURCE_DIR/pysparkbuild.json
-fix_template $RESOURCE_DIR/pysparkbuild.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
-set_template $RESOURCE_DIR/pysparkbuild.json
+cp $PYSPARK_DIR/pythonbuild.json $RESOURCE_DIR/pythonbuild.json
+fix_template $RESOURCE_DIR/pythonbuild.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
+set_template $RESOURCE_DIR/pythonbuild.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_fixed_app_name pyspark-build
 

--- a/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark/builddc/pysparkbuilddc.sh
@@ -10,9 +10,9 @@ source $SCRIPT_DIR/../../builddc
 PYSPARK_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i')/templates
 RESOURCE_DIR=$TEST_DIR/resources
 
-cp  $PYSPARK_DIR/pysparkbuilddc.json $RESOURCE_DIR/pysparkbuilddc.json
-fix_template $RESOURCE_DIR/pysparkbuilddc.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
-set_template $RESOURCE_DIR/pysparkbuilddc.json
+cp  $PYSPARK_DIR/pythonbuilddc.json $RESOURCE_DIR/pythonbuilddc.json
+fix_template $RESOURCE_DIR/pythonbuilddc.json radanalyticsio/radanalytics-pyspark $S2I_TEST_IMAGE_PYSPARK
+set_template $RESOURCE_DIR/pythonbuilddc.json
 set_git_uri https://github.com/radanalyticsio/s2i-integration-test-apps
 set_worker_count $S2I_TEST_WORKERS
 set_fixed_app_name pyspark-build

--- a/test/e2e/templates/pyspark/dc/pysparkdc.sh
+++ b/test/e2e/templates/pyspark/dc/pysparkdc.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 source $SCRIPT_DIR/../../builddc
 
 PYSPARK_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"` | grep -o '.*/oshinko-s2i')/templates
-set_template $PYSPARK_DIR/pysparkdc.json
+set_template $PYSPARK_DIR/pythondc.json
 set_worker_count $S2I_TEST_WORKERS
 
 # Clear these flags


### PR DESCRIPTION
This change brings the various templates into alignment with each other
and updates their options to be more consistent and useable.

Changes
* add a generic job template
* add java templates for dc
* add a scala template for dc
* reorganize parameter sections to share ordering and descriptions
* add a Service object to java build-dc and dc templates
* add a Service object to scala build-dc and dc templates
* rename pyspark* templates to python*
* remove pysparkjob.json
* add a readme file to template dir