### PR TITLE
Adding a way to pass the python dependencies to spark job

### DIFF
--- a/java-build/modules/common/added/utils/start.sh
+++ b/java-build/modules/common/added/utils/start.sh
@@ -317,8 +317,8 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
-    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
-        PY_FILES="--py-files dependencies.zip"
+    if [ -f "$APP_ROOT/src/worker-gen-dependencies.zip" ]; then
+        PY_FILES="--py-files worker-gen-dependencies.zip"
     fi
 
     if [ -n "$APP_MAIN_CLASS" ]; then

--- a/java-build/modules/common/added/utils/start.sh
+++ b/java-build/modules/common/added/utils/start.sh
@@ -317,6 +317,10 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
+    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
+        PY_FILES="--py-files dependencies.zip"
+    fi
+
     if [ -n "$APP_MAIN_CLASS" ]; then
         CLASS_OPTION="--class $APP_MAIN_CLASS"
     elif [ "$(unzip -p $APP_ROOT/src/$APP_FILE META-INF/MANIFEST.MF | grep -i main-class)" ]; then
@@ -330,8 +334,8 @@ else
         driver_host=
     fi
 
-    echo spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-    spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
+    echo spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
+    spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
     PID=$!
     wait $PID
 

--- a/modules/common/added/utils/start.sh
+++ b/modules/common/added/utils/start.sh
@@ -317,8 +317,8 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
-    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
-        PY_FILES="--py-files dependencies.zip"
+    if [ -f "$APP_ROOT/src/worker-gen-dependencies.zip" ]; then
+        PY_FILES="--py-files worker-gen-dependencies.zip"
     fi
 
     if [ -n "$APP_MAIN_CLASS" ]; then

--- a/modules/common/added/utils/start.sh
+++ b/modules/common/added/utils/start.sh
@@ -317,6 +317,10 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
+    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
+        PY_FILES="--py-files dependencies.zip"
+    fi
+
     if [ -n "$APP_MAIN_CLASS" ]; then
         CLASS_OPTION="--class $APP_MAIN_CLASS"
     elif [ "$(unzip -p $APP_ROOT/src/$APP_FILE META-INF/MANIFEST.MF | grep -i main-class)" ]; then
@@ -330,8 +334,8 @@ else
         driver_host=
     fi
 
-    echo spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-    spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
+    echo spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
+    spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
     PID=$!
     wait $PID
 

--- a/modules/pyspark/added/s2i/assemble
+++ b/modules/pyspark/added/s2i/assemble
@@ -16,12 +16,12 @@ echo "---> Proceeding with customized assemble ..."
 r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
 if [ -f "$APP_ROOT/src/$r_file" ]; then
     pushd $APP_ROOT/src
-    echo "---> Building dependencies.zip based on $r_file ..."
+    echo "---> Building worker-gen-dependencies.zip based on $r_file ..."
     pip install --upgrade pip
-    pip install -t dependencies -r $r_file
-    pushd dependencies
-    zip -r ../dependencies.zip .
-    export PYTHON_WORKER_DEPS=`readlink -f ../dependencies.zip`
+    pip install -t worker-gen-dependencies -r $r_file
+    pushd worker-gen-dependencies
+    zip -r ../worker-gen-dependencies.zip .
+    export PYTHON_WORKER_DEPS=`readlink -f ../worker-gen-dependencies.zip`
     popd
     popd
 fi

--- a/modules/pyspark/added/s2i/assemble
+++ b/modules/pyspark/added/s2i/assemble
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+shopt -s dotglob
+
+# first run the original assemble script
+/usr/libexec/s2i/assemble.orig
+
+echo "---> Proceeding with customized assemble ..."
+
+# If the root of the repo contains file (worker-)requirements.txt, install them and bundle
+# them together into big zip file that will be passed to spark-submit.
+
+# note: the idea of worker-requirements.txt is to isolate those dependencies that
+# are necessary only for spark workers, because not all the dependencies driver needs
+# are also needed on the worker nodes
+r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
+if [ -f "$APP_ROOT/src/$r_file" ]; then
+    pushd $APP_ROOT/src
+    echo "---> Building dependencies.zip based on $r_file ..."
+    pip install --upgrade pip
+    pip install -t dependencies -r $r_file
+    pushd dependencies
+    zip -r ../dependencies.zip .
+    export PYTHON_WORKER_DEPS=`readlink -f ../dependencies.zip`
+    popd
+    popd
+fi
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root

--- a/modules/pyspark/added/s2i/assemble
+++ b/modules/pyspark/added/s2i/assemble
@@ -7,13 +7,13 @@ shopt -s dotglob
 
 echo "---> Proceeding with customized assemble ..."
 
-# If the root of the repo contains file (worker-)requirements.txt, install them and bundle
+# If the root of the repo contains file called worker-requirements.txt, install them and bundle
 # them together into big zip file that will be passed to spark-submit.
 
 # note: the idea of worker-requirements.txt is to isolate those dependencies that
 # are necessary only for spark workers, because not all the dependencies driver needs
 # are also needed on the worker nodes
-r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
+r_file="worker-requirements.txt"
 if [ -f "$APP_ROOT/src/$r_file" ]; then
     pushd $APP_ROOT/src
     echo "---> Building worker-gen-dependencies.zip based on $r_file ..."

--- a/modules/pyspark/install
+++ b/modules/pyspark/install
@@ -31,6 +31,7 @@ then
 fi
 
 mkdir -p /usr/libexec/s2i
+mv /usr/libexec/s2i/assemble /usr/libexec/s2i/assemble.orig
 cp -r $ADDED_DIR/s2i/* /usr/libexec/s2i
 cp $ADDED_DIR/spark-conf/* /opt/spark/conf/
 chown -R 185:0 -R $APP_ROOT && chmod a+rwX -R $APP_ROOT

--- a/pyspark-build/modules/common/added/utils/start.sh
+++ b/pyspark-build/modules/common/added/utils/start.sh
@@ -317,8 +317,8 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
-    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
-        PY_FILES="--py-files dependencies.zip"
+    if [ -f "$APP_ROOT/src/worker-gen-dependencies.zip" ]; then
+        PY_FILES="--py-files worker-gen-dependencies.zip"
     fi
 
     if [ -n "$APP_MAIN_CLASS" ]; then

--- a/pyspark-build/modules/common/added/utils/start.sh
+++ b/pyspark-build/modules/common/added/utils/start.sh
@@ -317,6 +317,10 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
+    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
+        PY_FILES="--py-files dependencies.zip"
+    fi
+
     if [ -n "$APP_MAIN_CLASS" ]; then
         CLASS_OPTION="--class $APP_MAIN_CLASS"
     elif [ "$(unzip -p $APP_ROOT/src/$APP_FILE META-INF/MANIFEST.MF | grep -i main-class)" ]; then
@@ -330,8 +334,8 @@ else
         driver_host=
     fi
 
-    echo spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-    spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
+    echo spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
+    spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
     PID=$!
     wait $PID
 

--- a/pyspark-build/modules/pyspark/added/s2i/assemble
+++ b/pyspark-build/modules/pyspark/added/s2i/assemble
@@ -16,12 +16,12 @@ echo "---> Proceeding with customized assemble ..."
 r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
 if [ -f "$APP_ROOT/src/$r_file" ]; then
     pushd $APP_ROOT/src
-    echo "---> Building dependencies.zip based on $r_file ..."
+    echo "---> Building worker-gen-dependencies.zip based on $r_file ..."
     pip install --upgrade pip
-    pip install -t dependencies -r $r_file
-    pushd dependencies
-    zip -r ../dependencies.zip .
-    export PYTHON_WORKER_DEPS=`readlink -f ../dependencies.zip`
+    pip install -t worker-gen-dependencies -r $r_file
+    pushd worker-gen-dependencies
+    zip -r ../worker-gen-dependencies.zip .
+    export PYTHON_WORKER_DEPS=`readlink -f ../worker-gen-dependencies.zip`
     popd
     popd
 fi

--- a/pyspark-build/modules/pyspark/added/s2i/assemble
+++ b/pyspark-build/modules/pyspark/added/s2i/assemble
@@ -13,7 +13,7 @@ echo "---> Proceeding with customized assemble ..."
 # note: the idea of worker-requirements.txt is to isolate those dependencies that
 # are necessary only for spark workers, because not all the dependencies driver needs
 # are also needed on the worker nodes
-r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
+r_file="worker-requirements.txt"
 if [ -f "$APP_ROOT/src/$r_file" ]; then
     pushd $APP_ROOT/src
     echo "---> Building worker-gen-dependencies.zip based on $r_file ..."

--- a/pyspark-build/modules/pyspark/added/s2i/assemble
+++ b/pyspark-build/modules/pyspark/added/s2i/assemble
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+shopt -s dotglob
+
+# first run the original assemble script
+/usr/libexec/s2i/assemble.orig
+
+echo "---> Proceeding with customized assemble ..."
+
+# If the root of the repo contains file (worker-)requirements.txt, install them and bundle
+# them together into big zip file that will be passed to spark-submit.
+
+# note: the idea of worker-requirements.txt is to isolate those dependencies that
+# are necessary only for spark workers, because not all the dependencies driver needs
+# are also needed on the worker nodes
+r_file=`[ -f "$APP_ROOT/src/worker-requirements.txt" ] && echo worker-requirements.txt || echo requirements.txt`
+if [ -f "$APP_ROOT/src/$r_file" ]; then
+    pushd $APP_ROOT/src
+    echo "---> Building dependencies.zip based on $r_file ..."
+    pip install --upgrade pip
+    pip install -t dependencies -r $r_file
+    pushd dependencies
+    zip -r ../dependencies.zip .
+    export PYTHON_WORKER_DEPS=`readlink -f ../dependencies.zip`
+    popd
+    popd
+fi
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root

--- a/pyspark-build/modules/pyspark/install
+++ b/pyspark-build/modules/pyspark/install
@@ -31,6 +31,7 @@ then
 fi
 
 mkdir -p /usr/libexec/s2i
+mv /usr/libexec/s2i/assemble /usr/libexec/s2i/assemble.orig
 cp -r $ADDED_DIR/s2i/* /usr/libexec/s2i
 cp $ADDED_DIR/spark-conf/* /opt/spark/conf/
 chown -R 185:0 -R $APP_ROOT && chmod a+rwX -R $APP_ROOT

--- a/scala-build/modules/common/added/utils/start.sh
+++ b/scala-build/modules/common/added/utils/start.sh
@@ -317,8 +317,8 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
-    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
-        PY_FILES="--py-files dependencies.zip"
+    if [ -f "$APP_ROOT/src/worker-gen-dependencies.zip" ]; then
+        PY_FILES="--py-files worker-gen-dependencies.zip"
     fi
 
     if [ -n "$APP_MAIN_CLASS" ]; then

--- a/scala-build/modules/common/added/utils/start.sh
+++ b/scala-build/modules/common/added/utils/start.sh
@@ -317,6 +317,10 @@ else
     # app can use it if it likes.
     export OSHINKO_SPARK_MASTER=$master
 
+    if [ -f "$APP_ROOT/src/dependencies.zip" ]; then
+        PY_FILES="--py-files dependencies.zip"
+    fi
+
     if [ -n "$APP_MAIN_CLASS" ]; then
         CLASS_OPTION="--class $APP_MAIN_CLASS"
     elif [ "$(unzip -p $APP_ROOT/src/$APP_FILE META-INF/MANIFEST.MF | grep -i main-class)" ]; then
@@ -330,8 +334,8 @@ else
         driver_host=
     fi
 
-    echo spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
-    spark-submit $CLASS_OPTION --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
+    echo spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS
+    spark-submit $CLASS_OPTION $PY_FILES --master $master $driver_host $SPARK_OPTIONS $APP_ROOT/src/$APP_FILE $APP_ARGS &
     PID=$!
     wait $PID
 


### PR DESCRIPTION
If some custom code is executed by worker (some lambda in map for instance) all the libraries has to be present. spark-submit provides a way to pass the bundled dependencies as zip file as mentioned [here](https://stackoverflow.com/questions/36461054/i-cant-seem-to-get-py-files-on-spark-to-work/39777410#39777410). And this is basically what the change does. It looks into source directory in the repo if the `requirements.txt` file is present (I am not python ninja, but I believe it's a Python convention) and if yes, it uses pip to install the deps into directory that is zipped and passed to spark submit.

I am not sure about it's a good idea to send all the deps in that requirements file, because I think it's perfectly fine not to send the library if it's executed only on driver, so it's open question whether it would be better to have a special file called like `worker-requirements.txt` containing only those deps that are necessary on workers.

PS sorry for removing the whitespaces and making the PR more complex, I blame Atom. Here is the [link](https://github.com/radanalyticsio/oshinko-s2i/commit/7617c8e8da2983ce69c20fca2fba8c2c3cc74c67?w=1) to changes that ignores white spaces.