### PR TITLE
Remove explicit "app" labels

### DIFF
--- a/templates/javabuilddc.json
+++ b/templates/javabuilddc.json
@@ -278,10 +278,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/javadc.json
+++ b/templates/javadc.json
@@ -190,10 +190,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/pythonbuilddc.json
+++ b/templates/pythonbuilddc.json
@@ -267,10 +267,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/pythondc.json
+++ b/templates/pythondc.json
@@ -179,10 +179,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/scalabuilddc.json
+++ b/templates/scalabuilddc.json
@@ -294,10 +294,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+            "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/scaladc.json
+++ b/templates/scaladc.json
@@ -190,10 +190,7 @@
          "kind": "Service",
          "apiVersion": "v1",
          "metadata": {
-            "name": "${APPLICATION_NAME}",
-            "labels": {
-                "app": "${APPLICATION_NAME}"
-            }
+             "name": "${APPLICATION_NAME}"
          },
          "spec": {
              "ports": [

--- a/templates/sparkjob.json
+++ b/templates/sparkjob.json
@@ -74,9 +74,6 @@
               "parallelism": 1,
               "template": {
                   "metadata": {
-                      "labels": {
-                          "app": "${APPLICATION_NAME}"
-                      },
                       "name": "${APPLICATION_NAME}"
                   },
                   "spec": {


### PR DESCRIPTION
If 'oc new-app --template' is used to launch a template, as
opposed to 'oc proces -f xxx | oc create -f -', then "app"
labels will be added to objects created from the template.
As such, we should avoid adding our own app labels, and
we should avoid searching for the app label in test code etc.