### PR TITLE
Remove zero-tarballs from context target

### DIFF
--- a/Makefile.java
+++ b/Makefile.java
@@ -33,7 +33,6 @@ $(DOCKERFILE_CONTEXT): $(DOCKERFILE_CONTEXT)/Dockerfile $(DOCKERFILE_CONTEXT)/mo
 $(DOCKERFILE_CONTEXT)/Dockerfile $(DOCKERFILE_CONTEXT)/scripts:
 	concreate generate --descriptor image.java.yaml
 	cp -R target/image/* $(DOCKERFILE_CONTEXT)
-	$(MAKE) zero-tarballs
 
 zero-tarballs:
 	find ./$(DOCKERFILE_CONTEXT) -name *.tar.gz -type f -exec truncate -s 0 {} \;

--- a/Makefile.scala
+++ b/Makefile.scala
@@ -33,7 +33,6 @@ $(DOCKERFILE_CONTEXT): $(DOCKERFILE_CONTEXT)/Dockerfile $(DOCKERFILE_CONTEXT)/mo
 $(DOCKERFILE_CONTEXT)/Dockerfile $(DOCKERFILE_CONTEXT)/modules:
 	concreate generate --descriptor image.scala.yaml
 	cp -R target/image/* $(DOCKERFILE_CONTEXT)
-	$(MAKE) zero-tarballs
 
 zero-tarballs:
 	find ./$(DOCKERFILE_CONTEXT) -name *.tgz -type f -exec truncate -s 0 {} \;


### PR DESCRIPTION
Zeroing out the tarballs should be separate from
building the context dir since it really depends on
the destination of the build dir.