### PR TITLE
Handle tags on test images

### DIFF
--- a/test/e2e/templates/builddc
+++ b/test/e2e/templates/builddc
@@ -477,7 +477,12 @@ function fix_template() {
         docker push ${registry}/${pushproj}/${pushimage}
         if [ "$imagestream" == true ]; then
             sed -i "s^\"kind\": \"DockerImage\"^\"kind\": \"ImageStreamTag\"^" $file
-            sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushimage:latest\"^" $file
+            # if there is already a tag in the name, don't add latest
+            if [[ "$pushimage" == *:* ]]; then 
+                sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushimage\"^" $file
+            else
+                sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushimage:latest\"^" $file
+            fi
         else
             sed -i "s^\"name\": \"$original_image\"^\"name\": \"$pushproj/$pushimage\"^" $file
         fi


### PR DESCRIPTION
If a test image already contains a tag, don't add "latest". This
can happen when an s2i test image is specified with an env var
and it already contains a tag.