### PR TITLE
correct mispelled label name

### DIFF
--- a/templates/pythonbuilddc.json
+++ b/templates/pythonbuilddc.json
@@ -177,12 +177,12 @@
             ],
             "replicas": 1,
             "selector": {
-               "deploymentconfig": "${APPLICATION_NAME}"
+               "deploymentConfig": "${APPLICATION_NAME}"
             },
             "template": {
                "metadata": {
                   "labels": {
-                     "deploymentconfig": "${APPLICATION_NAME}"
+                     "deploymentConfig": "${APPLICATION_NAME}"
                   }
                },
                "spec": {

--- a/templates/pythondc.json
+++ b/templates/pythondc.json
@@ -88,12 +88,12 @@
             ],
             "replicas": 1,
             "selector": {
-               "deploymentconfig": "${APPLICATION_NAME}"
+               "deploymentConfig": "${APPLICATION_NAME}"
             },
             "template": {
                "metadata": {
                   "labels": {
-                     "deploymentconfig": "${APPLICATION_NAME}"
+                     "deploymentConfig": "${APPLICATION_NAME}"
                   }
                },
                "spec": {


### PR DESCRIPTION
The deployment config selector label was incorrect causing the services
not to associate with python deployment pods. This change corrects the
naming error.