### PR TITLE
add spark identifier to template names

### DIFF
--- a/templates/pythonbuild.json
+++ b/templates/pythonbuild.json
@@ -2,7 +2,7 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-python-build",
+      "name": "oshinko-python-spark-build",
       "annotations": {
          "description": "Create a buildconfig and imagestream using source-to-image and Python Spark source files hosted in git"
       }

--- a/templates/pythonbuilddc.json
+++ b/templates/pythonbuilddc.json
@@ -2,7 +2,7 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-python-build-dc",
+      "name": "oshinko-python-spark-build-dc",
       "annotations": {
          "openshift.io/display-name": "Apache Spark Python",
          "description": "Create a buildconfig, imagestream and deploymentconfig using source-to-image and Python Spark source files hosted in git"

--- a/templates/pythondc.json
+++ b/templates/pythondc.json
@@ -2,7 +2,7 @@
    "kind": "Template",
    "apiVersion": "v1",
    "metadata": {
-      "name": "oshinko-python-dc",
+      "name": "oshinko-python-spark-dc",
       "annotations": {
          "description": "Create a deploymentconfig using an existing Python Spark image"
       }


### PR DESCRIPTION
The python templates were slightly different than the other languages,
now they should all follow the same pattern.