### PR TITLE
Add a listing of the cluster config before spark-submit

### DIFF
--- a/modules/common/added/utils/start.sh
+++ b/modules/common/added/utils/start.sh
@@ -293,6 +293,9 @@ function use_spark_standalone {
         wait_for_master_ui $masterweb
         wait_for_workers_alive $desired $masterweb
 
+        echo Cluster configuration is
+        $CLI get $OSHINKO_CLUSTER_NAME $CLI_ARGS -o json --nopods
+
         # Now that we know what the master url is, export it so that the
         # app can use it if it likes.
         export OSHINKO_SPARK_MASTER=$master


### PR DESCRIPTION
This change logs the output of "oshinko get cluster -o json"
before running spark-submit.