### PR TITLE
Add application name to the oshinko application env

### DIFF
--- a/templates/javabuilddc.json
+++ b/templates/javabuilddc.json
@@ -207,6 +207,10 @@
                         "image": "${APPLICATION_NAME}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/javadc.json
+++ b/templates/javadc.json
@@ -110,6 +110,10 @@
                         "image": "${IMAGE}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/pythonbuilddc.json
+++ b/templates/pythonbuilddc.json
@@ -201,6 +201,10 @@
                         "image": "${APPLICATION_NAME}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/pythondc.json
+++ b/templates/pythondc.json
@@ -103,6 +103,10 @@
                         "image": "${IMAGE}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/scalabuilddc.json
+++ b/templates/scalabuilddc.json
@@ -223,6 +223,10 @@
                         "image": "${APPLICATION_NAME}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/scaladc.json
+++ b/templates/scaladc.json
@@ -110,6 +110,10 @@
                         "image": "${IMAGE}",
                         "env": [
                            {
+                              "name": "APPLICATION_NAME",
+                              "value": "${APPLICATION_NAME}"
+                           },
+                           {
                               "name": "DRIVER_HOST",
                               "value": "${APPLICATION_NAME}-headless"
                            },

--- a/templates/sparkjob.json
+++ b/templates/sparkjob.json
@@ -83,6 +83,10 @@
                               "name": "${APPLICATION_NAME}",
                               "env": [
                                 {
+                                   "name": "APPLICATION_NAME",
+                                   "value": "${APPLICATION_NAME}"
+                                },
+                                {
                                    "name": "DRIVER_HOST",
                                    "value": "${APPLICATION_NAME}-headless"
                                 },


### PR DESCRIPTION
The application name is used by the kubernetes native scheduling
option in start.sh to derive the name of the driver/executor
image.