### PR TITLE
Updating Travis-ci tests to use oc version v3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,66 +8,20 @@ matrix:
   # no need to include the build target at present because the template
   # tests perform builds from the local source to do the tests
   include:
-    - env: TO_TEST=pyspark-templates
-    - env: TO_TEST=java-templates
-    - env: TO_TEST=scala-templates-radio
-    - env: TO_TEST=scala-templates-dc
-    - env: TO_TEST=operations
-    - env: TO_TEST=incomplete
+    - env: TO_TEST=pyspark-templates OPENSHIFT_VERSION=v3.9
+    - env: TO_TEST=java-templates OPENSHIFT_VERSION=v3.9
+    - env: TO_TEST=scala-templates-radio OPENSHIFT_VERSION=v3.9
+    - env: TO_TEST=scala-templates-dc OPENSHIFT_VERSION=v3.9
+    - env: TO_TEST=operations OPENSHIFT_VERSION=v3.9
+    - env: TO_TEST=incomplete OPENSHIFT_VERSION=v3.9
   fast_finish: true
 
 before_install:
-## add insecure-registry and restart docker
-- |
-  if [ "$TO_TEST" != "build" ]; then
-      pwd
-      bash --version
-      sudo apt-get install --only-upgrade bash
-      bash --version
-      sudo cat /etc/default/docker
-      sudo service docker stop
-      sudo sed -i -e 's/sock/sock --insecure-registry 172.30.0.0\/16/' /etc/default/docker
-      sudo cat /etc/default/docker
-      sudo service docker start
-      sudo service docker status
-      sudo mkdir -p /home/travis/gopath/src/github.com/radanalyticsio/origin
-      ## download oc binary
-      sudo wget https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-client-tools-v3.7.0-7ed6862-linux-64bit.tar.gz -O ../origin/openshift-origin-client-tools.tar.gz
-      sudo wget https://github.com/openshift/origin/releases/download/v3.7.0/openshift-origin-server-v3.7.0-7ed6862-linux-64bit.tar.gz -O ../origin/openshift-origin-server.tar.gz
-      sudo ls -l /home/travis/gopath/src/github.com/radanalyticsio/origin
-      sudo tar -C /bin --strip-components=1 -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-client-tools.tar.gz
-      sudo tar -C /bin --strip-components=1 -xvzf /home/travis/gopath/src/github.com/radanalyticsio/origin/openshift-origin-server.tar.gz
-      oc version
-      export PATH=$PATH:/home/travis/gopath/src/github.com/radanalyticsio/origin/
-      echo $PATH
-      # below cmd is important to get oc working in ubuntu
-      sudo docker run -v /:/rootfs -ti --rm --entrypoint=/bin/bash --privileged openshift/origin:v3.7.0 -c "mv /rootfs/bin/findmnt /rootfs/bin/findmnt.backup"
-
-      # Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
-      # See if a retry within the same test works
-      set +e
-      built=false
-      while true; do
-          oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
-          if [ "$?" -eq 0 ]; then
-              ./test/travis-help/travis-check-pods.sh
-              if [ "$?" -eq 0 ]; then
-                  built=true
-                  break
-              fi
-          fi
-          echo "Retrying oc cluster up after failure"
-          oc cluster down
-          sleep 5
-      done
-      set -e
-      if [ "$built" == false ]; then
-          exit 1
-      fi
-      # travis-check-pods.sh left us in the default project
-      oc project myproject
-  fi
-
+- pwd
+- bash --version
+- sudo apt-get install --only-upgrade bash
+- bash --version
+- test/travis-help/prepare.sh
 install:
 before_script:
 - test/travis-help/check-tarballs.sh

--- a/test/travis-help/prepare.sh
+++ b/test/travis-help/prepare.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copies oc binary out of official openshift origin image
+# Note:  this expects the OPENSHIFT_VERSION env variable to be set.
+function download_openshift() {
+  echo "Downloading oc binary for OPENSHIFT_VERSION=${OPENSHIFT_VERSION}"
+  sudo docker cp $(docker create docker.io/openshift/origin:$OPENSHIFT_VERSION):/bin/oc /usr/local/bin/oc
+  oc version
+}
+
+function setup_insecure_registry() {
+# add insecure-registry and restart docker
+ sudo cat /etc/default/docker
+ sudo service docker stop
+ sudo sed -i -e 's/sock/sock --insecure-registry 172.30.0.0\/16/' /etc/default/docker
+ sudo cat /etc/default/docker
+ sudo service docker start
+ sudo service docker status
+}
+
+function start_and_verify_openshift() {
+  # Sometimes oc cluster up fails with a permission error and works when the test is relaunched.
+  # See if a retry within the same test works
+  set +e
+  built=false
+  while true; do
+      oc cluster up --host-config-dir=/home/travis/gopath/src/github.com/radanalyticsio/origin
+      if [ "$?" -eq 0 ]; then
+          ./test/travis-help/travis-check-pods.sh
+          if [ "$?" -eq 0 ]; then
+              built=true
+              break
+          fi
+      fi
+      echo "Retrying oc cluster up after failure"
+      oc cluster down
+      sleep 5
+  done
+  set -e
+  if [ "$built" == false ]; then
+      exit 1
+  fi
+  # travis-check-pods.sh left us in the default project
+  oc project myproject
+}
+
+setup_insecure_registry
+download_openshift
+start_and_verify_openshift


### PR DESCRIPTION
Updating Travis-ci tests to use oc version v3.9.  Also refactoring to simplify .travis.yml.