### PR TITLE
fix spacing error in start.sh

### DIFF
--- a/modules/common/added/utils/start.sh
+++ b/modules/common/added/utils/start.sh
@@ -88,7 +88,7 @@ function exit_flag {
 }
 
 function get_app_file {
-    if [ -z "$APP_FILE"]; then
+    if [ -z "$APP_FILE" ]; then
         case "$APP_LANG" in
             java | scala)
                 file_count "*.jar"


### PR DESCRIPTION
This change adds a space to a test clause for the APP_FILE presence.