### PR TITLE
update selector labels for sparkjob.json

### DIFF
--- a/templates/sparkjob.json
+++ b/templates/sparkjob.json
@@ -70,11 +70,17 @@
               "name": "${APPLICATION_NAME}"
           },
           "spec": {
+              "selector": {
+                  "radanalytics.io/Job": "${APPLICATION_NAME}"
+              },
               "completions": "${COMPLETIONS}",
               "parallelism": 1,
               "template": {
                   "metadata": {
-                      "name": "${APPLICATION_NAME}"
+                      "name": "${APPLICATION_NAME}",
+                      "labels": {
+                         "radanalytics.io/Job": "${APPLICATION_NAME}"
+                      }
                   },
                   "spec": {
                       "containers": [
@@ -182,7 +188,7 @@
                  }
              ],
              "selector": {
-                 "deploymentConfig": "${APPLICATION_NAME}"
+                 "radanalytics.io/Job": "${APPLICATION_NAME}"
              }
          }
       }


### PR DESCRIPTION
The service associated with the spark job template was using a selector
label that did not exist on the job object. This change updates the name
of the selector to be more relevant, and add the necessary labels to the
job object.