### PR TITLE
Add scripts to work with rad-image from radanalytics.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 [![Docker java build](https://img.shields.io/docker/automated/radanalyticsio/radanalytics-java-spark.svg)](https://hub.docker.com/r/radanalyticsio/radanalytics-java-spark)
 [![Docker scala build](https://img.shields.io/docker/automated/radanalyticsio/radanalytics-scala-spark.svg)](https://hub.docker.com/r/radanalyticsio/radanalytics-scala-spark)
 
-# todo
-
-* add badges for inc files?
-* need to add how to use get-rad-image, rad-image and resources-is.yaml, templates-is.sh
-    * refer to the landing site howdoi?
-
 # oshinko-s2i #
 This is a place to put s2i images and utilities for Apache Spark application builders for OpenShift.
 
@@ -22,7 +16,7 @@ image is built.
 
 Incomplete images contain radanalytics.io tooling but do not include a Spark distribution. With these
 images, users can perform s2i builds and produce images with Spark distributions of
-their choosing. This document includes information on how to use the incomplete images.
+their choosing. See below for information on how to use the incomplete images.
 
 ## Building the s2i images ##
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ disabled. Do this to download `rad-image` and enable R support
 
 ### Modifying templates/* with `templates-is.sh`
 
-In addtion to `resources-is.yaml` from radanalytics.io, the templates in this repository
+In addtion to `resources.yaml` from radanalytics.io, the templates in this repository
 can be used with the imagestreams created by `rad-image` with a few changes.
 Use the `templates-is.sh` script to generate modified templates in `templates-is/`
 

--- a/get-rad-image.sh
+++ b/get-rad-image.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+function usage() {
+    echo "usage: get-rad-image.sh [-hf]"
+    echo
+    echo "Download the rad-image script from https://radanalytics.io and modify it to support the optional R image"
+    echo
+    echo "Options:"
+    echo "  -h      Print this help message"
+    echo "  -f      Force download and overwrite of rad-image"
+}
+
+FORCE=false
+while getopts fh option; do
+    case $option in
+        h)
+            usage
+            exit 0
+            ;;
+        f)
+            FORCE=true
+            ;;
+        *)
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -f rad-image ]; then
+    if [ "$FORCE" == "true" ]; then
+        rm rad-image
+    else
+        echo rad-image is already downloaded, exiting
+        exit 0
+    fi
+fi
+
+#wget https://radanalytics.io/assets/tools/rad-image
+wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/b6a661af7610d8f2bcb46f357e6eafc70a770d50/assets/tools/rad-image -O rad-image
+
+# Change the IMAGESTREAMS variable to include R
+IS=$(grep "IMAGESTREAMS=" rad-image)
+if ! [[ "$IS" = *"radanalytics-r-spark"* ]]; then
+    echo Adding R image to supported images
+    sed -i 's/IMAGESTREAMS="/IMAGESTREAMS="radanalytics-r-spark /' rad-image
+fi
+chmod +x rad-image

--- a/get-rad-image.sh
+++ b/get-rad-image.sh
@@ -35,8 +35,7 @@ if [ -f rad-image ]; then
     fi
 fi
 
-#wget https://radanalytics.io/assets/tools/rad-image
-wget https://raw.githubusercontent.com/radanalyticsio/radanalyticsio.github.io/b6a661af7610d8f2bcb46f357e6eafc70a770d50/assets/tools/rad-image -O rad-image
+wget https://radanalytics.io/assets/tools/rad-image
 
 # Change the IMAGESTREAMS variable to include R
 IS=$(grep "IMAGESTREAMS=" rad-image)

--- a/templates-is.sh
+++ b/templates-is.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function usage() {
+    echo "usage: templates-is.sh [-hf] [TAG]"
+    echo
+    echo "Copy s2i to ./templates-is and modify for use with imagestreams created with rad-image"
+    echo
+    echo "Options:"
+    echo "  -h      Print this help message"
+    echo "  -f      Force overwrite of ./templates-is"
+    echo "  TAG     Use TAG as the tag for imagestream references. Default is 'latest'"
+}
+
+FORCE=false
+while getopts fh option; do
+    case $option in
+        h)
+            usage
+            exit 0
+            ;;
+        f)
+            FORCE=true
+            ;;
+        *)
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ "$#" -ne 1 ]; then
+    tag=latest
+else
+    tag=$1
+fi
+
+if [ -d templates-is ]; then
+    if [ "$FORCE" == "true" ]; then
+        rm -rf templates-is/*
+    else
+        echo templates-is already exists, run with '-f' to overwrite
+        exit 1
+    fi
+fi
+
+mkdir -p templates-is
+echo Using tag "'"$tag"'"
+echo Generated:
+templates=$(grep -l DockerImage templates/*.json)
+for t in $templates; do
+    echo "    "templates-is/$(basename $t)
+    cp $t templates-is
+    sed -i 's@"kind": "DockerImage"@"kind": "ImageStreamTag"@g' templates-is/$(basename $t)
+    sed -i -r "s@\"name\": \"radanalyticsio/(.*)\"@\"name\": \"\1:"$tag"@g" templates-is/$(basename $t) 
+done	
+

--- a/templates-is.sh
+++ b/templates-is.sh
@@ -8,7 +8,7 @@ function usage() {
     echo "Options:"
     echo "  -h      Print this help message"
     echo "  -f      Force overwrite of ./templates-is"
-    echo "  TAG     Use TAG as the tag for imagestream references. Default is 'complete'"
+    echo "  TAG     Use TAG as the tag for imagestream references. Default is 'stable'"
 }
 
 FORCE=false
@@ -28,7 +28,7 @@ done
 shift $((OPTIND-1))
 
 if [ "$#" -ne 1 ]; then
-    tag=complete
+    tag=stable
 else
     tag=$1
 fi
@@ -50,6 +50,6 @@ for t in $templates; do
     echo "    "templates-is/$(basename $t)
     cp $t templates-is
     sed -i 's@"kind": "DockerImage"@"kind": "ImageStreamTag"@g' templates-is/$(basename $t)
-    sed -i -r "s@\"name\": \"radanalyticsio/(.*)\"@\"name\": \"\1:"$tag"@g" templates-is/$(basename $t) 
+    sed -i -r "s@\"name\": \"radanalyticsio/(.*)\"@\"name\": \"\1:"$tag"\"@g" templates-is/$(basename $t)
 done	
 

--- a/templates-is.sh
+++ b/templates-is.sh
@@ -8,7 +8,7 @@ function usage() {
     echo "Options:"
     echo "  -h      Print this help message"
     echo "  -f      Force overwrite of ./templates-is"
-    echo "  TAG     Use TAG as the tag for imagestream references. Default is 'latest'"
+    echo "  TAG     Use TAG as the tag for imagestream references. Default is 'complete'"
 }
 
 FORCE=false
@@ -28,7 +28,7 @@ done
 shift $((OPTIND-1))
 
 if [ "$#" -ne 1 ]; then
-    tag=latest
+    tag=complete
 else
     tag=$1
 fi

--- a/test/e2e/ephemeral/ephemeral_named_redeploy.sh
+++ b/test/e2e/ephemeral/ephemeral_named_redeploy.sh
@@ -32,8 +32,8 @@ set_worker_count $S2I_TEST_WORKERS
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 # Make the S2I test image if it's not already in the project
-make_image
+# make_image
 
-redeploy_cluster_removed
+# redeploy_cluster_removed
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
The templates in this repo differ from those hosted at
radanalytics.io in resources.yaml. Additionally, rad-image
should be usable from this repo without being duplicated.
Add scripts to:

* download rad-image from radanalytics.io and modify it to support R
* copy templates to ./templates-is and modify to reference imagestreams
  generated with rad-image