### PR TITLE
Modify template tests which use resources.yaml

### DIFF
--- a/test/e2e/common
+++ b/test/e2e/common
@@ -316,6 +316,9 @@ function cleanup_app() {
             os::cmd::try_until_failure 'oc get pod/"$POD_NAME"' $((10*minute))
         fi
     fi
+    # In some cases we may have a deploy pod hanging around that is still terminating
+    # Wait for them to disappear
+    os::cmd::try_until_text 'oc get pods -l openshift.io/deployer-pod-for.name' 'No resources found'
     set -e
 }
 

--- a/test/e2e/templates/pyspark-py27/radio/radio_pysparkbuilddc.sh
+++ b/test/e2e/templates/pyspark-py27/radio/radio_pysparkbuilddc.sh
@@ -23,14 +23,22 @@ else
     echo Using https://radanalytics.io/resources.yaml
     oc create -f https://radanalytics.io/resources.yaml &> /dev/null
 fi
-oc export template oshinko-python-spark-build-dc -o json > $RESOURCE_DIR/oshinko-python-spark-build-dc.json
-fix_template $RESOURCE_DIR/oshinko-python-spark-build-dc.json radanalyticsio/radanalytics-pyspark:stable $S2I_TEST_IMAGE_PYSPARK
+oc get template oshinko-python-spark-build-dc -o json > $RESOURCE_DIR/oshinko-python-spark-build-dc.json
+
+# If we're using non-local images, we can use the template as is
+if [ "$S2I_TEST_LOCAL_IMAGES" == "true" ]; then
+    fix_template $RESOURCE_DIR/oshinko-python-spark-build-dc.json radanalyticsio/radanalytics-pyspark:stable $S2I_TEST_IMAGE_PYSPARK
+fi
 set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
-echo "++ check_image"
-check_image $S2I_TEST_IMAGE_PYSPARK
+# The purpose of check_image is to make sure the templates reference
+# the image we expect. If we're using non-local images, then we don't need this check
+if [ "$S2I_TEST_LOCAL_IMAGES" == "true" ]; then
+    echo "++ check_image"
+    check_image $S2I_TEST_IMAGE_PYSPARK
+fi
 
 # Do this first after check_image becaue it involves deleting all the existing buildconfigs
 echo "++ test_no_app_name"

--- a/test/e2e/templates/scala/radio/radio_ivy.sh
+++ b/test/e2e/templates/scala/radio/radio_ivy.sh
@@ -25,8 +25,11 @@ else
     oc create -f https://radanalytics.io/resources.yaml &> /dev/null
 fi
 
-oc export template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
-fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark:stable $S2I_TEST_IMAGE_SCALA
+oc get template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
+# If we're using non-local images, we can use the template as is
+if [ "$S2I_TEST_LOCAL_IMAGES" == "true" ]; then
+    fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark:stable $S2I_TEST_IMAGE_SCALA
+fi
 set -e
 
 function test_ivy_perms {

--- a/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
+++ b/test/e2e/templates/scala/radio/radio_scalabuilddc.sh
@@ -24,14 +24,22 @@ else
     echo Using https://radanalytics.io/resources.yaml
     oc create -f https://radanalytics.io/resources.yaml &> /dev/null
 fi
-oc export template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
-fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark:stable $S2I_TEST_IMAGE_SCALA
+oc get template oshinko-scala-spark-build-dc -o json > $RESOURCE_DIR/oshinko-scala-spark-build-dc.json
+
+# If we're using non-local images, we can use the template as is
+if [ "$S2I_TEST_LOCAL_IMAGES" == "true" ]; then
+    fix_template $RESOURCE_DIR/oshinko-scala-spark-build-dc.json radanalyticsio/radanalytics-scala-spark:stable $S2I_TEST_IMAGE_SCALA
+fi
 set -e
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
-echo "++ check_image"
-check_image $S2I_TEST_IMAGE_SCALA
+# The purpose of check_image is to make sure the templates reference
+# the image we expect. If we're using non-local images, then we don't need this check
+if [ "$S2I_TEST_LOCAL_IMAGES" == "true" ]; then
+    echo "++ check_image"
+    check_image $S2I_TEST_IMAGE_SCALA
+fi
 
 # Do this first after check_image becaue it involves deleting all the existing buildconfigs
 echo "++ test_no_app_name"


### PR DESCRIPTION
* If non-local images are being used for tests, the template
  doesn't need to be modified and check_image doesn't need to run

* Also add a check to cleanup_app to wait for all deployment
  pods to disappear