### PR TITLE
Override cluster check

### DIFF
--- a/java-build-inc/modules/common/added/utils/start.sh
+++ b/java-build-inc/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/java-build/modules/common/added/utils/start.sh
+++ b/java-build/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/modules/common/added/utils/start.sh
+++ b/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/pyspark-build-inc/modules/common/added/utils/start.sh
+++ b/pyspark-build-inc/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/pyspark-build/modules/common/added/utils/start.sh
+++ b/pyspark-build/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/pyspark-py36-build-inc/modules/common/added/utils/start.sh
+++ b/pyspark-py36-build-inc/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/pyspark-py36-build/modules/common/added/utils/start.sh
+++ b/pyspark-py36-build/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/scala-build-inc/modules/common/added/utils/start.sh
+++ b/scala-build-inc/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/scala-build/modules/common/added/utils/start.sh
+++ b/scala-build/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/sparklyr-build-inc/modules/common/added/utils/start.sh
+++ b/sparklyr-build-inc/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1

--- a/sparklyr-build/modules/common/added/utils/start.sh
+++ b/sparklyr-build/modules/common/added/utils/start.sh
@@ -418,11 +418,11 @@ function use_spark_url_override {
 
     # test url to ensure it is consumable
     echo $master | grep "^spark://.*:[0-9]\+$" >> /dev/null 2>&1
-    if [ "$1" -ne 0]; do
+    if [ "$1" -ne 0]; then
         echo "SPARK_URL_OVERRIDE contains a URL that is not processable."
         echo "URL should be in the form of \"spark://host:port\""
         app_exit
-    done
+    fi
 
     # convert url to a device file we can query
     master_tcp=$(echo $master | sed -e 's/spark:\/\//\/dev\/tcp\//' | sed -e 's/:/\//') >> /dev/null 2>&1


### PR DESCRIPTION
this change brings in a simple url and connectivity check for the spark url override. this is accomplished by inspecting the url to ensure that it is in the format `spark://host:port`, and then attempting to ensure that the connection is open by `echo /dev/tcp/host/port`. if it fails for 30 seconds it will call `app_exit`.